### PR TITLE
Change tracking_uri to use SQLite database

### DIFF
--- a/configs/logging/mlflow.yaml
+++ b/configs/logging/mlflow.yaml
@@ -2,7 +2,7 @@
 _target_: FRAME_FM.training.logger.create_mlflow_logger
 
 experiment_name: "frame-fm-eurosat-ae"
-tracking_uri: ${env:MLFLOW_TRACKING_URI, "file:./mlruns"}
+tracking_uri: ${env:MLFLOW_TRACKING_URI, "sqlite://./mlruns/mlflow.db"}
 run_name: "eurosat_autoencoder"
 
 tags:


### PR DESCRIPTION
Reading the MLflow doc, there will be a change at some point to reivew the soon-to-be-deprecated file system as a backend approch, therefore we should move to a database by default.