### PR TITLE
Geometry utils

### DIFF
--- a/src/FRAME_FM/utils/geometry_utils/__init__.py
+++ b/src/FRAME_FM/utils/geometry_utils/__init__.py
@@ -1,0 +1,18 @@
+from .api import get_centroids, get_bounds
+from .geometry import PixelGeometry, TileGeometry, TiledArrayGeometry
+from .exceptions import (
+    CRSUnresolvableError,
+    DimNotFoundError,
+    ExpectedDimsMismatchError,
+)
+
+__all__ = [
+    "get_centroids",
+    "get_bounds",
+    "PixelGeometry",
+    "TileGeometry",
+    "TiledArrayGeometry",
+    "CRSUnresolvableError",
+    "DimNotFoundError",
+    "ExpectedDimsMismatchError",
+]

--- a/src/FRAME_FM/utils/geometry_utils/api.py
+++ b/src/FRAME_FM/utils/geometry_utils/api.py
@@ -1,0 +1,146 @@
+"""
+Public API for geometry_utils.
+
+The two entry points — ``get_centroids`` and ``get_bounds`` — accept any
+Xarray object and dispatch to the correct geometry class automatically.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import numpy as np
+import xarray as xr
+
+from .geometry import from_xarray
+
+_TIME_LETTER = "t"
+_BY_VALUES = ("tile", "pixel")
+
+
+def _ns_to_datetime64(value: float) -> np.datetime64:
+    return np.datetime64(int(value), "ns")
+
+
+def _apply_time_as_datetime_dict(result: dict[str, Any]) -> dict[str, Any]:
+    inner = result.get("centroid") or result.get("bounds")
+    key = "centroid" if "centroid" in result else "bounds"
+    if inner is None or _TIME_LETTER not in inner:
+        return result
+    converted = dict(inner)
+    val = converted[_TIME_LETTER]
+    if isinstance(val, tuple):
+        converted[_TIME_LETTER] = (_ns_to_datetime64(val[0]), _ns_to_datetime64(val[1]))
+    else:
+        converted[_TIME_LETTER] = _ns_to_datetime64(val)
+    return {**result, key: converted}
+
+
+def _apply_time_as_datetime_dataset(ds: xr.Dataset) -> xr.Dataset:
+    updates: dict[str, xr.DataArray] = {}
+    for var in ds.data_vars:
+        if var in ("centroid_t", "bounds_t_min", "bounds_t_max"):
+            updates[var] = xr.DataArray(
+                ds[var].values.astype("int64").astype("datetime64[ns]"),
+                coords=ds[var].coords, dims=ds[var].dims, attrs=ds[var].attrs,
+            )
+    return ds.assign(updates) if updates else ds
+
+
+def _validate_by(by: str) -> None:
+    if by not in _BY_VALUES:
+        raise ValueError(f"`by` must be one of {_BY_VALUES!r}, got {by!r}.")
+
+
+def get_centroids(
+    obj: xr.DataArray | xr.Dataset,
+    *,
+    expected: str | list[str] | None = None,
+    chosen: str | list[str] | None = None,
+    crs: str | None = None,
+    target_crs: str | None = None,
+    by: Literal["tile", "pixel"] = "pixel",
+    time_as_datetime: bool = False,
+) -> dict[str, Any] | xr.Dataset:
+    """
+    Return centroids of an Xarray object.
+
+    Parameters
+    ----------
+    obj : xr.DataArray or xr.Dataset
+    expected : str or list[str], optional
+        Dimension letters that must exist as tiled coordinates.
+    chosen : str or list[str], optional
+        Subset of expected dimensions to include.
+    crs : str, optional
+        Source CRS.  Auto-detected if not given.
+    target_crs : str, optional
+        Output CRS for reprojection (requires pyproj).
+    by : {"pixel", "tile"}, default "pixel"
+        * ``"pixel"`` — one centroid per pixel in the fine grid.
+          Returns an ``xr.Dataset`` with fine-dim coordinates, shaped
+          ``(<fine_dim>,)`` for a tile or ``(tile, <fine_dim>)`` for a
+          tiled array.
+        * ``"tile"`` — one centroid for the whole tile.  Returns a dict
+          for a single tile/pixel, or an ``xr.Dataset`` (one row per tile)
+          for a tiled array.
+    time_as_datetime : bool, default False
+        Return ``t`` values as ``numpy.datetime64`` instead of float ns.
+    """
+    _validate_by(by)
+    geom = from_xarray(obj, expected=expected, crs=crs)
+    result = (
+        geom.pixel_centroid(chosen=chosen, target_crs=target_crs)
+        if by == "pixel"
+        else geom.centroid(chosen=chosen, target_crs=target_crs)
+    )
+    if time_as_datetime:
+        result = (
+            _apply_time_as_datetime_dict(result)
+            if isinstance(result, dict)
+            else _apply_time_as_datetime_dataset(result)
+        )
+    return result
+
+
+def get_bounds(
+    obj: xr.DataArray | xr.Dataset,
+    *,
+    expected: str | list[str] | None = None,
+    chosen: str | list[str] | None = None,
+    crs: str | None = None,
+    target_crs: str | None = None,
+    by: Literal["tile", "pixel"] = "pixel",
+    time_as_datetime: bool = False,
+) -> dict[str, Any] | xr.Dataset:
+    """
+    Return spatial bounds of an Xarray object.
+
+    Parameters
+    ----------
+    obj : xr.DataArray or xr.Dataset
+    expected : str or list[str], optional
+    chosen : str or list[str], optional
+    crs : str, optional
+    target_crs : str, optional
+    by : {"pixel", "tile"}, default "pixel"
+        * ``"pixel"`` — ``bounds_<letter>_min`` / ``bounds_<letter>_max``
+          per pixel, half-cell padded from coordinate spacing.
+        * ``"tile"`` — one bounding box per tile (full spatial envelope).
+    time_as_datetime : bool, default False
+        Return ``t`` values as ``numpy.datetime64`` instead of float ns.
+    """
+    _validate_by(by)
+    geom = from_xarray(obj, expected=expected, crs=crs)
+    result = (
+        geom.pixel_bounds(chosen=chosen, target_crs=target_crs)
+        if by == "pixel"
+        else geom.bounds(chosen=chosen, target_crs=target_crs)
+    )
+    if time_as_datetime:
+        result = (
+            _apply_time_as_datetime_dict(result)
+            if isinstance(result, dict)
+            else _apply_time_as_datetime_dataset(result)
+        )
+    return result

--- a/src/FRAME_FM/utils/geometry_utils/constants.py
+++ b/src/FRAME_FM/utils/geometry_utils/constants.py
@@ -1,0 +1,28 @@
+"""
+Canonical dimension alias map.
+
+Each key is a single-letter dimension code used in `expected` / `chosen` strings.
+Each value is an ordered list of coordinate name aliases to search for (case-insensitive).
+The first match found in the Xarray object wins.
+"""
+
+DIM_ALIASES: dict[str, list[str]] = {
+    "t": ["time", "t"],
+    "z": ["z", "depth", "level", "band"],
+    "y": ["y", "lat", "latitude"],
+    "x": ["x", "lon", "longitude"],
+}
+
+# Suffixes produced by coarsen() -> construct() -> stack() -> transpose()
+COARSE_SUFFIX = "_coarse"
+FINE_SUFFIX = "_fine"
+
+# Coordinate attributes / dataset attributes that may carry CRS information
+CRS_ATTR_NAMES = ["crs", "grid_mapping", "spatial_ref", "proj4", "epsg"]
+
+# Lat/lon alias sets — used to auto-detect EPSG:4326
+LAT_ALIASES = {"lat", "latitude", "y"}  # 'y' only counts if paired with x=lon alias
+LON_ALIASES = {"lon", "longitude", "x"}
+
+# Fallback CRS when lat/lon names are detected
+LATLON_CRS = "EPSG:4326"

--- a/src/FRAME_FM/utils/geometry_utils/crs.py
+++ b/src/FRAME_FM/utils/geometry_utils/crs.py
@@ -1,0 +1,118 @@
+"""
+CRS resolution utilities.
+
+Priority order:
+  1. Explicitly passed crs= argument
+  2. obj.attrs["crs"] / obj.attrs["grid_mapping"] / other known attr names
+  3. rioxarray .rio.crs if available
+  4. Coordinate name heuristic (lat/lon names → EPSG:4326)
+  5. Raise CRSUnresolvableError
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import xarray as xr
+
+from .constants import CRS_ATTR_NAMES, LAT_ALIASES, LON_ALIASES, LATLON_CRS
+from .exceptions import CRSUnresolvableError
+
+if TYPE_CHECKING:
+    pass
+
+
+def resolve_crs(obj: xr.DataArray | xr.Dataset, explicit_crs: str | None) -> str:
+    """
+    Resolve the CRS of *obj*, returning a string understood by pyproj.
+
+    Parameters
+    ----------
+    obj:
+        The Xarray object whose CRS we want to determine.
+    explicit_crs:
+        A CRS string passed directly by the caller (highest priority).
+        If *None*, the function falls through to auto-detection.
+
+    Returns
+    -------
+    str
+        A CRS string (e.g. ``"EPSG:4326"``, a PROJ string, or a WKT).
+
+    Raises
+    ------
+    CRSUnresolvableError
+        When the CRS cannot be determined by any method.
+    """
+    # 1. Explicit argument wins immediately.
+    if explicit_crs is not None:
+        return explicit_crs
+
+    # 2. Check object / coordinate attributes.
+    crs = _crs_from_attrs(obj)
+    if crs is not None:
+        return crs
+
+    # 3. Try rioxarray accessor (optional dependency).
+    crs = _crs_from_rio(obj)
+    if crs is not None:
+        return crs
+
+    # 4. Heuristic: lat/lon coordinate names → EPSG:4326.
+    if _looks_like_latlon(obj):
+        return LATLON_CRS
+
+    raise CRSUnresolvableError(
+        "Cannot determine CRS for the provided Xarray object.\n"
+        "Please pass `crs=` explicitly, e.g. crs='EPSG:4326' or crs='EPSG:32633'.\n"
+        "Alternatively, set obj.attrs['crs'] = '<your crs string>'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _crs_from_attrs(obj: xr.DataArray | xr.Dataset) -> str | None:
+    """Search known CRS attribute names on the object and its coordinates."""
+    sources = [obj.attrs]
+    # Also inspect coordinate attributes — rasterio often writes to a
+    # 'spatial_ref' coordinate rather than the top-level attrs.
+    for coord in obj.coords.values():
+        sources.append(coord.attrs)
+
+    for attrs in sources:
+        for key in CRS_ATTR_NAMES:
+            if key in attrs:
+                value = attrs[key]
+                if isinstance(value, (str, int)):
+                    return str(value) if isinstance(value, int) else value
+    return None
+
+
+def _crs_from_rio(obj: xr.DataArray | xr.Dataset) -> str | None:
+    """Try to read CRS via rioxarray if it is installed and attached."""
+    try:
+        import rioxarray  # noqa: F401 — side-effect import attaches .rio
+        rio_crs = obj.rio.crs
+        if rio_crs is not None:
+            return str(rio_crs)
+    except (ImportError, AttributeError, Exception):
+        pass
+    return None
+
+
+def _looks_like_latlon(obj: xr.DataArray | xr.Dataset) -> bool:
+    """
+    Return True when the object's coordinate names suggest geographic lat/lon.
+
+    Requires *both* a lat-like and a lon-like coordinate name to be present
+    (to avoid false positives for purely latitude or longitude 1-D objects).
+    """
+    coord_names = {c.lower() for c in obj.coords}
+    dim_names = {d.lower() for d in obj.dims}
+    all_names = coord_names | dim_names
+
+    has_lat = bool(all_names & LAT_ALIASES)
+    has_lon = bool(all_names & LON_ALIASES)
+    return has_lat and has_lon

--- a/src/FRAME_FM/utils/geometry_utils/dims.py
+++ b/src/FRAME_FM/utils/geometry_utils/dims.py
@@ -1,0 +1,252 @@
+"""
+Dimension resolution and object-type detection.
+
+Responsibilities
+----------------
+* Map single-letter dim codes ("t", "z", "y", "x") to the actual coordinate
+  names found in an Xarray object, accounting for the ``_coarse`` / ``_fine``
+  suffix convention.
+* Validate that the object's tiled dims match an ``expected`` string.
+* Classify an Xarray object as one of: "pixel", "tile", "tiled_array".
+"""
+
+from __future__ import annotations
+
+import xarray as xr
+
+from .constants import COARSE_SUFFIX, DIM_ALIASES, FINE_SUFFIX
+from .exceptions import DimNotFoundError, ExpectedDimsMismatchError
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+OBJECT_TYPES = ("pixel", "tile", "tiled_array")
+
+# Maps a dim letter to the resolved base name (e.g. "y" → "lat")
+# and the coarse/fine coordinate names actually present.
+class ResolvedDim:
+    """Container for one resolved tiling dimension."""
+
+    def __init__(
+        self,
+        letter: str,
+        base_name: str,
+        coarse_name: str,
+        fine_name: str,
+    ) -> None:
+        self.letter = letter          # e.g. "y"
+        self.base_name = base_name    # e.g. "lat"
+        self.coarse_name = coarse_name  # e.g. "lat_coarse"
+        self.fine_name = fine_name      # e.g. "lat_fine"
+
+    def __repr__(self) -> str:
+        return (
+            f"ResolvedDim(letter={self.letter!r}, base={self.base_name!r}, "
+            f"coarse={self.coarse_name!r}, fine={self.fine_name!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dim string parsing
+# ---------------------------------------------------------------------------
+
+def parse_dim_string(dims: str | list[str] | None) -> list[str]:
+    """
+    Normalise *dims* to a lowercase list of single-letter codes.
+
+    Accepts:
+      * ``"tyx"``         → ``["t", "y", "x"]``
+      * ``["t", "y", "x"]`` → ``["t", "y", "x"]``
+      * ``None``          → ``[]``
+    """
+    if dims is None:
+        return []
+    if isinstance(dims, str):
+        return [c for c in dims.lower() if not c.isspace()]
+    return [d.lower().strip() for d in dims]
+
+
+# ---------------------------------------------------------------------------
+# Dim resolution
+# ---------------------------------------------------------------------------
+
+def resolve_dims(
+    obj: xr.DataArray | xr.Dataset,
+    dim_letters: list[str],
+    *,
+    strict: bool = True,
+) -> dict[str, ResolvedDim]:
+    """
+    For each letter in *dim_letters*, find the matching ``_coarse`` and
+    ``_fine`` coordinates in *obj*.
+
+    Parameters
+    ----------
+    obj:
+        The Xarray object to inspect.
+    dim_letters:
+        Ordered list of single-letter dim codes, e.g. ``["t", "y", "x"]``.
+    strict:
+        If *True* (default), raise :class:`DimNotFoundError` when a letter
+        cannot be resolved.  Set to *False* to silently skip unresolved dims.
+
+    Returns
+    -------
+    dict[str, ResolvedDim]
+        Keyed by letter code.
+    """
+    all_names: set[str] = set(obj.coords) | set(obj.dims)
+    resolved: dict[str, ResolvedDim] = {}
+
+    for letter in dim_letters:
+        aliases = DIM_ALIASES.get(letter)
+        if aliases is None:
+            raise DimNotFoundError(
+                f"Unknown dimension letter {letter!r}. "
+                f"Supported letters: {sorted(DIM_ALIASES.keys())}"
+            )
+
+        matched: ResolvedDim | None = None
+        for alias in aliases:
+            coarse = alias + COARSE_SUFFIX
+            fine = alias + FINE_SUFFIX
+            if coarse in all_names and fine in all_names:
+                matched = ResolvedDim(
+                    letter=letter,
+                    base_name=alias,
+                    coarse_name=coarse,
+                    fine_name=fine,
+                )
+                break
+
+        if matched is None:
+            if strict:
+                candidates = [
+                    f"{a}{COARSE_SUFFIX} / {a}{FINE_SUFFIX}"
+                    for a in aliases
+                ]
+                raise DimNotFoundError(
+                    f"Could not find tiled coordinates for dimension {letter!r}.\n"
+                    f"Looked for (any of): {candidates}\n"
+                    f"Available names: {sorted(all_names)}"
+                )
+        else:
+            resolved[letter] = matched
+
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Expected-dims validation
+# ---------------------------------------------------------------------------
+
+def validate_expected(
+    obj: xr.DataArray | xr.Dataset,
+    expected: str | list[str] | None,
+) -> dict[str, ResolvedDim]:
+    """
+    Validate that *obj* has tiled (``_coarse`` / ``_fine``) coordinates for
+    every letter in *expected*.
+
+    Returns the resolved dim map so callers don't have to resolve twice.
+
+    Unlike :func:`resolve_dims`, this function returns an empty dict rather
+    than raising when no coarse/fine coordinates are found at all — that
+    signals a pixel object to the factory, which handles it separately.
+
+    Raises :class:`ExpectedDimsMismatchError` only when *some* but not all
+    of the expected dims have coarse/fine coords (a genuine mismatch), or
+    when an unknown dim letter is given.
+    """
+    letters = parse_dim_string(expected)
+    if not letters:
+        return {}
+
+    resolved = resolve_dims(obj, letters, strict=False)
+
+    # If nothing resolved at all AND the caller explicitly provided `expected`,
+    # this is a genuine mismatch (e.g. raw non-tiled data passed with expected="tzyx").
+    # Return empty only when no expected was given — that signals a pixel to the factory.
+    missing = [l for l in letters if l not in resolved]
+    if missing:
+        # Nothing resolved at all — no coarse/fine structure found for any dim.
+        if not resolved:
+            raise ExpectedDimsMismatchError(
+                f"Object does not match `expected` dims {expected!r}. "
+                f"No coarse/fine tiling coordinates were found for any of: {letters}. "
+                f"Available coordinates: {sorted(set(obj.coords) | set(obj.dims))}."
+            )
+        # Some resolved, some not → partial mismatch.
+        raise ExpectedDimsMismatchError(
+            f"Object does not match `expected` dims {expected!r}. "
+            f"Could not find coarse/fine coordinates for: {missing}. "
+            f"Found coarse/fine for: {list(resolved.keys())}."
+        )
+
+    return resolved
+
+
+def has_tiling_structure(obj: xr.DataArray | xr.Dataset) -> bool:
+    """
+    Return True if *obj* has any ``_coarse`` / ``_fine`` coordinate pairs,
+    indicating it was produced by the tiling pipeline.
+
+    Used by the factory to short-circuit ``validate_expected`` for plain
+    pixel objects that have no tiling structure at all.
+    """
+    all_names = set(obj.coords) | set(obj.dims)
+    return any(
+        (name.endswith(COARSE_SUFFIX) and name[:-len(COARSE_SUFFIX)] + FINE_SUFFIX in all_names)
+        for name in all_names
+    )
+
+
+# ---------------------------------------------------------------------------
+# Object-type detection
+# ---------------------------------------------------------------------------
+
+def detect_object_type(
+    obj: xr.DataArray | xr.Dataset,
+    resolved: dict[str, ResolvedDim],
+) -> str:
+    """
+    Classify *obj* as ``"pixel"``, ``"tile"``, or ``"tiled_array"``.
+
+    Classification rules
+    --------------------
+    * **tiled_array** – the object has a stacked MultiIndex dimension whose
+      levels include at least one ``_coarse`` coordinate, *or* any
+      ``_coarse`` coordinate has size > 1 along a non-fine axis.
+    * **tile** – ``_coarse`` coordinates exist but each has only a single
+      value (i.e. this is one tile).
+    * **pixel** – no ``_coarse`` / ``_fine`` coordinates at all, or all
+      spatial dims are scalar.
+    """
+    if not resolved:
+        return "pixel"
+
+    # Check for MultiIndex (stacked tiled array)
+    for dim in obj.dims:
+        idx = obj.indexes.get(dim)
+        if idx is not None and hasattr(idx, "levels"):
+            # pandas MultiIndex — check if any level matches a coarse name
+            level_names = set(idx.names)
+            coarse_names = {rd.coarse_name for rd in resolved.values()}
+            if level_names & coarse_names:
+                return "tiled_array"
+
+    # Fall back to size inspection on coarse coordinates
+    for rd in resolved.values():
+        if rd.coarse_name in obj.coords:
+            coarse_coord = obj.coords[rd.coarse_name]
+            if coarse_coord.size > 1:
+                return "tiled_array"
+
+    # All coarse coords have size == 1 → single tile
+    coarse_names = {rd.coarse_name for rd in resolved.values()}
+    if coarse_names & (set(obj.coords) | set(obj.dims)):
+        return "tile"
+
+    return "pixel"

--- a/src/FRAME_FM/utils/geometry_utils/exceptions.py
+++ b/src/FRAME_FM/utils/geometry_utils/exceptions.py
@@ -1,0 +1,13 @@
+class CRSUnresolvableError(Exception):
+    """Raised when the CRS of an Xarray object cannot be determined."""
+    pass
+
+
+class DimNotFoundError(Exception):
+    """Raised when a required dimension is not found in the Xarray object."""
+    pass
+
+
+class ExpectedDimsMismatchError(Exception):
+    """Raised when the object's tiled dimensions don't match the `expected` argument."""
+    pass

--- a/src/FRAME_FM/utils/geometry_utils/geometry.py
+++ b/src/FRAME_FM/utils/geometry_utils/geometry.py
@@ -1,0 +1,942 @@
+"""
+Geometry classes.
+
+Three classes cover the object-type spectrum:
+
+  PixelGeometry      – single pixel (no coarse/fine coords)
+  TileGeometry       – single tile  (coarse size == 1)
+  TiledArrayGeometry – array of tiles (coarse size > 1, or MultiIndex)
+
+All three share the same public interface:
+  .centroid(chosen, target_crs) → dict  or  xr.Dataset
+  .bounds(chosen, target_crs)   → dict  or  xr.Dataset
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from .constants import DIM_ALIASES, LATLON_CRS
+from .crs import resolve_crs
+from .dims import ResolvedDim, detect_object_type, has_tiling_structure, parse_dim_string, resolve_dims, validate_expected
+from .exceptions import DimNotFoundError, ExpectedDimsMismatchError
+from .inference import (
+    infer_bounds_coarse_fine,
+    infer_bounds_from_values,
+    midpoint,
+    reproject_bounds,
+    reproject_point,
+    to_float_ns,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result helpers
+# ---------------------------------------------------------------------------
+
+def _centroid_dict(coords: dict[str, float], crs: str) -> dict[str, Any]:
+    """Package centroid coordinates into a standard result dict."""
+    return {"centroid": coords, "crs": crs}
+
+
+def _bounds_dict(bounds: dict[str, tuple[float, float]], crs: str) -> dict[str, Any]:
+    """Package bounds into a standard result dict."""
+    return {"bounds": bounds, "crs": crs}
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+class _BaseGeometry:
+    """
+    Internal base holding the Xarray object, resolved dims, and source CRS.
+    Not part of the public API.
+    """
+
+    def __init__(
+        self,
+        obj: xr.DataArray | xr.Dataset,
+        resolved: dict[str, ResolvedDim],
+        src_crs: str,
+    ) -> None:
+        self._obj = obj
+        self._resolved = resolved
+        self._src_crs = src_crs
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    def _chosen_dims(self, chosen: str | list[str] | None) -> dict[str, ResolvedDim]:
+        """
+        Return the subset of resolved dims matching *chosen*.
+
+        If *chosen* is None, return all resolved dims.
+        """
+        letters = parse_dim_string(chosen)
+        if not letters:
+            return self._resolved
+
+        missing = [l for l in letters if l not in self._resolved]
+        if missing:
+            raise DimNotFoundError(
+                f"`chosen` dims {missing} are not in the resolved dims "
+                f"{list(self._resolved.keys())}. "
+                "Make sure they appear in `expected` too."
+            )
+        return {l: self._resolved[l] for l in letters}
+
+    def _maybe_reproject_point(
+        self,
+        coords: dict[str, float],
+        target_crs: str | None,
+    ) -> tuple[dict[str, float], str]:
+        """Optionally reproject a centroid point; return (coords, effective_crs)."""
+        if target_crs is None or target_crs == self._src_crs:
+            return coords, self._src_crs
+
+        # We need both x and y to reproject — check we have them.
+        xy_letters = [l for l in coords if l in ("x", "y")]
+        if len(xy_letters) < 2:
+            # Not enough spatial axes to reproject — return as-is with a note.
+            return coords, self._src_crs
+
+        x_val = coords["x"]
+        y_val = coords["y"]
+        x_new, y_new = reproject_point(x_val, y_val, self._src_crs, target_crs)
+        reprojected = {**coords, "x": x_new, "y": y_new}
+        return reprojected, target_crs
+
+    @staticmethod
+    def _infer_ref_dtype(raw_coarse: np.ndarray, raw_fine: np.ndarray) -> np.dtype:
+        """Kept for internal use only — detects whether a coord is temporal."""
+        import pandas as pd
+        if np.issubdtype(raw_fine.dtype, np.datetime64):
+            return raw_fine.dtype
+        if np.issubdtype(raw_coarse.dtype, np.datetime64):
+            return raw_coarse.dtype
+        if raw_coarse.dtype == object and raw_coarse.size > 0:
+            first = raw_coarse.ravel()[0]
+            if isinstance(first, (pd.Timestamp, np.datetime64)):
+                return np.dtype("datetime64[ns]")
+        return raw_coarse.dtype
+
+    def _resolve_coord_values(
+        self, rd: ResolvedDim
+    ) -> tuple[np.ndarray, bool]:
+        """
+        Return coordinate values as float64 and whether they are absolute.
+
+        Returns
+        -------
+        (float_values, is_absolute)
+            ``float_values`` – 1-D float64 array (ns for datetimes).
+            ``is_absolute``  – True if values already include the coarse
+                               origin; False if coarse must be added.
+        """
+        raw_coarse = np.asarray(self._obj.coords[rd.coarse_name].values)
+        raw_fine = np.asarray(self._obj.coords[rd.fine_name].values)
+
+        if rd.base_name in self._obj.coords:
+            raw_vals = np.asarray(self._obj.coords[rd.base_name].values).ravel()
+            return to_float_ns(raw_vals), True
+        else:
+            return to_float_ns(raw_fine.ravel()), False
+
+    def _maybe_reproject_bounds(
+        self,
+        bounds: dict[str, tuple[float, float]],
+        target_crs: str | None,
+    ) -> tuple[dict[str, tuple[float, float]], str]:
+        """Optionally reproject bounds; return (bounds, effective_crs)."""
+        if target_crs is None or target_crs == self._src_crs:
+            return bounds, self._src_crs
+
+        if "x" not in bounds or "y" not in bounds:
+            return bounds, self._src_crs
+
+        min_x, max_x = bounds["x"]
+        min_y, max_y = bounds["y"]
+        min_x_new, min_y_new, max_x_new, max_y_new = reproject_bounds(
+            min_x, min_y, max_x, max_y, self._src_crs, target_crs
+        )
+        reprojected = {
+            **bounds,
+            "x": (min_x_new, max_x_new),
+            "y": (min_y_new, max_y_new),
+        }
+        return reprojected, target_crs
+
+
+# ---------------------------------------------------------------------------
+# PixelGeometry
+# ---------------------------------------------------------------------------
+
+class PixelGeometry(_BaseGeometry):
+    """
+    Geometry for a single pixel (no ``_coarse`` / ``_fine`` tiling structure).
+
+    The centroid is the coordinate value itself; the bounds are inferred from
+    the coordinate value and its neighbours (if any), collapsing to a point
+    for a truly scalar coordinate.
+    """
+
+    def centroid(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Return the centroid of this pixel.
+
+        Parameters
+        ----------
+        chosen:
+            Dim letters to include in the result (subset of resolved dims).
+        target_crs:
+            Optional target CRS for reprojection of x/y coordinates.
+
+        Returns
+        -------
+        dict with keys ``"centroid"`` (dict of letter → value) and ``"crs"``.
+        """
+        chosen_dims = self._chosen_dims(chosen)
+        coords: dict[str, float] = {}
+
+        for letter, rd in chosen_dims.items():
+            # For a pixel, use the raw coordinate value (no coarse/fine).
+            base = rd.base_name
+            if base in self._obj.coords:
+                vals = np.asarray(self._obj.coords[base].values, dtype=float).ravel()
+                mn, mx = infer_bounds_from_values(vals)
+                coords[letter] = midpoint(mn, mx)
+            else:
+                raise DimNotFoundError(
+                    f"Coordinate {base!r} not found in object for pixel centroid."
+                )
+
+        coords, effective_crs = self._maybe_reproject_point(coords, target_crs)
+        return _centroid_dict(coords, effective_crs)
+
+    def bounds(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Return the bounds of this pixel.
+
+        Parameters
+        ----------
+        chosen:
+            Dim letters to include.
+        target_crs:
+            Optional target CRS.
+
+        Returns
+        -------
+        dict with keys ``"bounds"`` (dict of letter → (min, max)) and ``"crs"``.
+        """
+        chosen_dims = self._chosen_dims(chosen)
+        bounds: dict[str, tuple[float, float]] = {}
+
+        for letter, rd in chosen_dims.items():
+            base = rd.base_name
+            if base in self._obj.coords:
+                vals = np.asarray(self._obj.coords[base].values, dtype=float).ravel()
+                bounds[letter] = infer_bounds_from_values(vals)
+            else:
+                raise DimNotFoundError(
+                    f"Coordinate {base!r} not found in object for pixel bounds."
+                )
+
+        bounds, effective_crs = self._maybe_reproject_bounds(bounds, target_crs)
+        return _bounds_dict(bounds, effective_crs)
+
+    def pixel_centroid(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> dict[str, Any]:
+        """A pixel is already a single point — delegates to ``centroid``."""
+        return self.centroid(chosen=chosen, target_crs=target_crs)
+
+    def pixel_bounds(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> dict[str, Any]:
+        """A pixel is already a single point — delegates to ``bounds``."""
+        return self.bounds(chosen=chosen, target_crs=target_crs)
+
+class TileGeometry(_BaseGeometry):
+    """
+    Geometry for a single tile (coarse coords present but size == 1).
+    """
+
+    def centroid(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> dict[str, Any]:
+        """Return the centroid of this tile."""
+        chosen_dims = self._chosen_dims(chosen)
+        coords: dict[str, Any] = {}
+
+        for letter, rd in chosen_dims.items():
+            vals, is_absolute = self._resolve_coord_values(rd)
+            mn, mx = infer_bounds_from_values(vals)
+            if not is_absolute:
+                origin = to_float_ns(
+                    np.asarray(self._obj.coords[rd.coarse_name].values).ravel()
+                )[0]
+                mn, mx = origin + mn, origin + mx
+            coords[letter] = midpoint(mn, mx)
+
+        coords, effective_crs = self._maybe_reproject_point(coords, target_crs)
+        return _centroid_dict(coords, effective_crs)
+
+    def bounds(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> dict[str, Any]:
+        """Return the bounds of this tile."""
+        chosen_dims = self._chosen_dims(chosen)
+        bounds: dict[str, tuple[Any, Any]] = {}
+
+        for letter, rd in chosen_dims.items():
+            vals, is_absolute = self._resolve_coord_values(rd)
+            mn, mx = infer_bounds_from_values(vals)
+            if not is_absolute:
+                origin = to_float_ns(
+                    np.asarray(self._obj.coords[rd.coarse_name].values).ravel()
+                )[0]
+                mn, mx = origin + mn, origin + mx
+            bounds[letter] = (mn, mx)
+
+        bounds, effective_crs = self._maybe_reproject_bounds(bounds, target_crs)
+        return _bounds_dict(bounds, effective_crs)
+
+
+    def pixel_centroid(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> xr.Dataset:
+        """
+        Return one centroid per pixel in this tile as an ``xr.Dataset``.
+
+        The output has the fine coordinate dimension(s) as its index, with
+        one ``centroid_<letter>`` variable per chosen dim.
+        """
+        from .inference import infer_pixel_bounds
+        chosen_dims = self._chosen_dims(chosen)
+        data_vars: dict[str, xr.DataArray] = {}
+        fine_coords: dict[str, xr.DataArray] = {}
+
+        for letter, rd in chosen_dims.items():
+            abs_vals, is_absolute = self._resolve_coord_values(rd)
+            if not is_absolute:
+                origin = to_float_ns(
+                    np.asarray(self._obj.coords[rd.coarse_name].values).ravel()
+                )[0]
+                abs_vals = origin + abs_vals
+
+            fine_dim = rd.fine_name
+            fine_index = np.asarray(self._obj.coords[rd.fine_name].values).ravel()
+            if fine_dim not in fine_coords:
+                fine_coords[fine_dim] = xr.DataArray(fine_index, dims=[fine_dim])
+            data_vars[f"centroid_{letter}"] = xr.DataArray(
+                abs_vals, coords={fine_dim: fine_index}, dims=[fine_dim]
+            )
+
+        # Reproject x/y if needed
+        if target_crs is not None and target_crs != self._src_crs:
+            data_vars = self._reproject_pixel_centroids(data_vars, target_crs)
+
+        effective_crs = target_crs if target_crs else self._src_crs
+        ds = xr.Dataset(data_vars)
+        ds.attrs["crs"] = effective_crs
+        return ds
+
+    def pixel_bounds(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> xr.Dataset:
+        """
+        Return per-pixel bounds in this tile as an ``xr.Dataset``.
+
+        Variables are named ``bounds_<letter>_min`` / ``bounds_<letter>_max``.
+        """
+        from .inference import infer_pixel_bounds
+        chosen_dims = self._chosen_dims(chosen)
+        data_vars: dict[str, xr.DataArray] = {}
+
+        for letter, rd in chosen_dims.items():
+            abs_vals, is_absolute = self._resolve_coord_values(rd)
+            if not is_absolute:
+                origin = to_float_ns(
+                    np.asarray(self._obj.coords[rd.coarse_name].values).ravel()
+                )[0]
+                abs_vals = origin + abs_vals
+
+            fine_dim = rd.fine_name
+            fine_index = np.asarray(self._obj.coords[rd.fine_name].values).ravel()
+            mins, maxs = infer_pixel_bounds(abs_vals)
+            data_vars[f"bounds_{letter}_min"] = xr.DataArray(
+                mins, coords={fine_dim: fine_index}, dims=[fine_dim]
+            )
+            data_vars[f"bounds_{letter}_max"] = xr.DataArray(
+                maxs, coords={fine_dim: fine_index}, dims=[fine_dim]
+            )
+
+        if target_crs is not None and target_crs != self._src_crs:
+            data_vars = self._reproject_pixel_bounds(data_vars, target_crs)
+
+        effective_crs = target_crs if target_crs else self._src_crs
+        ds = xr.Dataset(data_vars)
+        ds.attrs["crs"] = effective_crs
+        return ds
+
+    def _reproject_pixel_centroids(
+        self,
+        data_vars: dict[str, xr.DataArray],
+        target_crs: str,
+    ) -> dict[str, xr.DataArray]:
+        """Reproject centroid_x / centroid_y pixel arrays."""
+        if "centroid_x" not in data_vars or "centroid_y" not in data_vars:
+            return data_vars
+        from pyproj import Transformer
+        transformer = Transformer.from_crs(self._src_crs, target_crs, always_xy=True)
+        xs_new, ys_new = transformer.transform(
+            data_vars["centroid_x"].values, data_vars["centroid_y"].values
+        )
+        updated = dict(data_vars)
+        updated["centroid_x"] = data_vars["centroid_x"].copy(data=xs_new)
+        updated["centroid_y"] = data_vars["centroid_y"].copy(data=ys_new)
+        return updated
+
+    def _reproject_pixel_bounds(
+        self,
+        data_vars: dict[str, xr.DataArray],
+        target_crs: str,
+    ) -> dict[str, xr.DataArray]:
+        """Reproject bounds_x_* / bounds_y_* pixel arrays."""
+        keys = ("bounds_x_min", "bounds_x_max", "bounds_y_min", "bounds_y_max")
+        if not all(k in data_vars for k in keys):
+            return data_vars
+        from pyproj import Transformer
+        transformer = Transformer.from_crs(self._src_crs, target_crs, always_xy=True)
+        x_min = data_vars["bounds_x_min"].values
+        x_max = data_vars["bounds_x_max"].values
+        y_min = data_vars["bounds_y_min"].values
+        y_max = data_vars["bounds_y_max"].values
+        corners_x = np.stack([x_min, x_max, x_max, x_min])
+        corners_y = np.stack([y_min, y_min, y_max, y_max])
+        cx_new, cy_new = transformer.transform(corners_x.ravel(), corners_y.ravel())
+        n = x_min.size
+        cx_new = cx_new.reshape(4, n)
+        cy_new = cy_new.reshape(4, n)
+        updated = dict(data_vars)
+        updated["bounds_x_min"] = data_vars["bounds_x_min"].copy(data=cx_new.min(axis=0))
+        updated["bounds_x_max"] = data_vars["bounds_x_max"].copy(data=cx_new.max(axis=0))
+        updated["bounds_y_min"] = data_vars["bounds_y_min"].copy(data=cy_new.min(axis=0))
+        updated["bounds_y_max"] = data_vars["bounds_y_max"].copy(data=cy_new.max(axis=0))
+        return updated
+
+class TiledArrayGeometry(_BaseGeometry):
+    """
+    Geometry for a DataArray / Dataset containing many tiles.
+
+    Results are returned as an ``xr.Dataset`` preserving the tile indexing
+    structure.  All coarse coordinate dimensions are kept as index coordinates
+    regardless of ``chosen``, so tiles remain uniquely addressable.
+    """
+
+    def centroid(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> xr.Dataset:
+        """
+        Return one centroid per tile as an ``xr.Dataset``.
+
+        Data variables are named ``centroid_<letter>`` for each letter in
+        *chosen*.  The tile MultiIndex (or coarse coords) are retained as
+        index coordinates.
+
+        Parameters
+        ----------
+        chosen:
+            Dim letters to compute centroids for.
+        target_crs:
+            Optional CRS for reprojecting x/y results.
+        """
+        chosen_dims = self._chosen_dims(chosen)
+        tile_index, tile_coords = self._build_tile_index()
+
+        data_vars: dict[str, xr.DataArray] = {}
+
+        for letter, rd in chosen_dims.items():
+            centroids = self._compute_per_tile_centroids(rd, tile_index)
+            data_vars[f"centroid_{letter}"] = xr.DataArray(
+                centroids, coords=tile_coords, dims=["tile"]
+            )
+
+        if target_crs is not None and target_crs != self._src_crs:
+            data_vars = self._reproject_dataset_centroids(data_vars, tile_coords, target_crs)
+
+        effective_crs = target_crs if target_crs else self._src_crs
+        ds = xr.Dataset(data_vars, coords=tile_coords)
+        ds.attrs["crs"] = effective_crs
+        return ds
+
+    def bounds(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> xr.Dataset:
+        """
+        Return bounds per tile as an ``xr.Dataset``.
+
+        Data variables are named ``bounds_<letter>_min`` and
+        ``bounds_<letter>_max`` for each letter in *chosen*.
+        """
+        chosen_dims = self._chosen_dims(chosen)
+        tile_index, tile_coords = self._build_tile_index()
+
+        data_vars: dict[str, xr.DataArray] = {}
+
+        for letter, rd in chosen_dims.items():
+            mins, maxs = self._compute_per_tile_bounds(rd, tile_index)
+            data_vars[f"bounds_{letter}_min"] = xr.DataArray(
+                mins, coords=tile_coords, dims=["tile"]
+            )
+            data_vars[f"bounds_{letter}_max"] = xr.DataArray(
+                maxs, coords=tile_coords, dims=["tile"]
+            )
+
+        if target_crs is not None and target_crs != self._src_crs:
+            data_vars = self._reproject_dataset_bounds(data_vars, tile_coords, target_crs)
+
+        effective_crs = target_crs if target_crs else self._src_crs
+        ds = xr.Dataset(data_vars, coords=tile_coords)
+        ds.attrs["crs"] = effective_crs
+        return ds
+
+    def pixel_centroid(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> xr.Dataset:
+        """
+        Return one centroid per pixel across all tiles as an ``xr.Dataset``.
+
+        Output dims are ``(tile, <fine_dim>)`` for each chosen dim.
+        Variables are named ``centroid_<letter>``.
+        """
+        from .inference import infer_pixel_bounds
+        chosen_dims = self._chosen_dims(chosen)
+        tile_index, tile_coords = self._build_tile_index()
+        n_tiles = len(tile_index)
+        data_vars: dict[str, xr.DataArray] = {}
+        all_coords = dict(tile_coords)
+
+        for letter, rd in chosen_dims.items():
+            fine_offsets = self._get_fine_offsets(rd)
+            fine_dim = rd.fine_name
+            fine_index = np.asarray(self._obj.coords[rd.fine_name].values).ravel()
+            n_fine = len(fine_index)
+            if fine_dim not in all_coords:
+                all_coords[fine_dim] = xr.DataArray(fine_index, dims=[fine_dim])
+
+            out = np.empty((n_tiles, n_fine), dtype=float)
+            for i, tile in enumerate(tile_index):
+                origin = to_float_ns(np.asarray([tile.get(rd.coarse_name, 0.0)]))[0]
+                out[i] = origin + fine_offsets
+
+            data_vars[f"centroid_{letter}"] = xr.DataArray(
+                out, coords={**tile_coords, fine_dim: fine_index},
+                dims=["tile", fine_dim],
+            )
+
+        if target_crs is not None and target_crs != self._src_crs:
+            data_vars = self._reproject_pixel_centroids_tiled(
+                data_vars, tile_coords, target_crs
+            )
+
+        effective_crs = target_crs if target_crs else self._src_crs
+        ds = xr.Dataset(data_vars, coords=all_coords)
+        ds.attrs["crs"] = effective_crs
+        return ds
+
+    def pixel_bounds(
+        self,
+        chosen: str | list[str] | None = None,
+        target_crs: str | None = None,
+    ) -> xr.Dataset:
+        """
+        Return per-pixel bounds across all tiles as an ``xr.Dataset``.
+
+        Output dims are ``(tile, <fine_dim>)`` for each chosen dim.
+        Variables are named ``bounds_<letter>_min`` / ``bounds_<letter>_max``.
+        """
+        from .inference import infer_pixel_bounds
+        chosen_dims = self._chosen_dims(chosen)
+        tile_index, tile_coords = self._build_tile_index()
+        n_tiles = len(tile_index)
+        data_vars: dict[str, xr.DataArray] = {}
+        all_coords = dict(tile_coords)
+
+        for letter, rd in chosen_dims.items():
+            fine_offsets = self._get_fine_offsets(rd)
+            fine_dim = rd.fine_name
+            fine_index = np.asarray(self._obj.coords[rd.fine_name].values).ravel()
+            n_fine = len(fine_index)
+            if fine_dim not in all_coords:
+                all_coords[fine_dim] = xr.DataArray(fine_index, dims=[fine_dim])
+
+            # Per-pixel half-steps are the same for every tile (uniform fine grid)
+            _, fine_maxs = infer_pixel_bounds(fine_offsets)
+            fine_mins_arr, _ = infer_pixel_bounds(fine_offsets)
+            pixel_mins = np.empty((n_tiles, n_fine), dtype=float)
+            pixel_maxs = np.empty((n_tiles, n_fine), dtype=float)
+
+            for i, tile in enumerate(tile_index):
+                origin = to_float_ns(np.asarray([tile.get(rd.coarse_name, 0.0)]))[0]
+                pixel_mins[i] = origin + fine_mins_arr
+                pixel_maxs[i] = origin + fine_maxs
+
+            data_vars[f"bounds_{letter}_min"] = xr.DataArray(
+                pixel_mins, coords={**tile_coords, fine_dim: fine_index},
+                dims=["tile", fine_dim],
+            )
+            data_vars[f"bounds_{letter}_max"] = xr.DataArray(
+                pixel_maxs, coords={**tile_coords, fine_dim: fine_index},
+                dims=["tile", fine_dim],
+            )
+
+        effective_crs = target_crs if target_crs else self._src_crs
+        ds = xr.Dataset(data_vars, coords=all_coords)
+        ds.attrs["crs"] = effective_crs
+        return ds
+
+    def _reproject_pixel_centroids_tiled(
+        self,
+        data_vars: dict[str, xr.DataArray],
+        tile_coords: dict[str, xr.DataArray],
+        target_crs: str,
+    ) -> dict[str, xr.DataArray]:
+        if "centroid_x" not in data_vars or "centroid_y" not in data_vars:
+            return data_vars
+        from pyproj import Transformer
+        transformer = Transformer.from_crs(self._src_crs, target_crs, always_xy=True)
+        xs = data_vars["centroid_x"].values.ravel()
+        ys = data_vars["centroid_y"].values.ravel()
+        xs_new, ys_new = transformer.transform(xs, ys)
+        updated = dict(data_vars)
+        updated["centroid_x"] = data_vars["centroid_x"].copy(
+            data=xs_new.reshape(data_vars["centroid_x"].shape)
+        )
+        updated["centroid_y"] = data_vars["centroid_y"].copy(
+            data=ys_new.reshape(data_vars["centroid_y"].shape)
+        )
+        return updated
+
+    # ------------------------------------------------------------------
+    # Private: tile indexing
+    # ------------------------------------------------------------------
+
+    def _build_tile_index(
+        self,
+    ) -> tuple[list[dict[str, Any]], dict[str, xr.DataArray]]:
+        """
+        Build a flat list of per-tile coordinate dicts and a matching
+        set of Dataset coords.
+
+        Returns
+        -------
+        tile_index : list[dict]
+            Each entry maps coarse coord name → scalar value for one tile.
+        tile_coords : dict[str, xr.DataArray]
+            Ready to pass as ``coords=`` to ``xr.Dataset``.
+        """
+        coarse_names = [rd.coarse_name for rd in self._resolved.values()]
+
+        # Try to use a MultiIndex dimension if one exists.
+        multi_dim = self._find_multi_dim(coarse_names)
+
+        if multi_dim is not None:
+            return self._index_from_multiindex(multi_dim, coarse_names)
+        else:
+            return self._index_from_coarse_coords(coarse_names)
+
+    def _find_multi_dim(self, coarse_names: list[str]) -> str | None:
+        """Return the name of a MultiIndex dimension covering coarse coords, or None."""
+        for dim in self._obj.dims:
+            idx = self._obj.indexes.get(dim)
+            if idx is not None and hasattr(idx, "levels"):
+                if set(idx.names) & set(coarse_names):
+                    return dim
+        return None
+
+    def _index_from_multiindex(
+        self, multi_dim: str, coarse_names: list[str]
+    ) -> tuple[list[dict[str, Any]], dict[str, xr.DataArray]]:
+        idx = self._obj.indexes[multi_dim]
+        tile_index = [
+            {name: val for name, val in zip(idx.names, key)}
+            for key in idx
+        ]
+        tile_coords: dict[str, xr.DataArray] = {
+            name: xr.DataArray(
+                [t[name] for t in tile_index], dims=["tile"]
+            )
+            for name in idx.names
+        }
+        return tile_index, tile_coords
+
+    def _index_from_coarse_coords(
+        self, coarse_names: list[str]
+    ) -> tuple[list[dict[str, Any]], dict[str, xr.DataArray]]:
+        """Build tile index from broadcasting coarse coordinate dims."""
+        import itertools
+
+        coarse_vals: dict[str, np.ndarray] = {}
+        for name in coarse_names:
+            if name in self._obj.coords:
+                coarse_vals[name] = np.asarray(
+                    self._obj.coords[name].values
+                ).ravel()  # preserve original dtype (datetime safe)
+
+        combinations = list(itertools.product(*coarse_vals.values()))
+        tile_index = [
+            dict(zip(coarse_vals.keys(), combo)) for combo in combinations
+        ]
+        tile_coords = {
+            name: xr.DataArray(
+                [t[name] for t in tile_index], dims=["tile"]
+            )
+            for name in coarse_vals
+        }
+        return tile_index, tile_coords
+
+    # ------------------------------------------------------------------
+    # Private: per-tile computation
+    # ------------------------------------------------------------------
+
+    def _select_tile(self, tile: dict[str, Any]) -> xr.DataArray | xr.Dataset:
+        """Select a single tile from the object using its coarse coord values."""
+        obj = self._obj
+        for coarse_name, val in tile.items():
+            if coarse_name in obj.coords and coarse_name in obj.dims:
+                obj = obj.sel({coarse_name: val})
+            elif coarse_name in obj.coords:
+                obj = obj.where(obj.coords[coarse_name] == val, drop=True)
+        return obj
+
+    def _get_fine_offsets(self, rd: ResolvedDim) -> np.ndarray:
+        """
+        Return within-tile coordinate offsets from the tile origin as float64.
+
+        After ``coarsen() → construct()``, ``_fine`` holds integer positional
+        indices (0, 1, 2, …).  Step size is derived from:
+
+        1. ``base_name`` dim coord — use first n_fine values, zero-based.
+        2. ``_fine`` is already datetime64 — zero-base as ns offsets.
+        3. Otherwise infer step from coarse spacing divided by n_fine.
+        """
+        raw_fine_idx = np.asarray(self._obj.coords[rd.fine_name].values).ravel()
+        n_fine = len(raw_fine_idx)
+
+        if rd.base_name in self._obj.coords:
+            base_vals = to_float_ns(
+                np.asarray(self._obj.coords[rd.base_name].values).ravel()
+            )
+            tile_vals = base_vals[:n_fine]
+            return tile_vals - tile_vals[0]
+        elif np.issubdtype(raw_fine_idx.dtype, np.datetime64):
+            fine_float = to_float_ns(raw_fine_idx)
+            return fine_float - fine_float[0]
+        else:
+            raw_coarse = self._obj.coords[rd.coarse_name].values
+            coarse_float = to_float_ns(np.asarray(raw_coarse).ravel())
+            step = (coarse_float[1] - coarse_float[0]) / n_fine if coarse_float.size >= 2 else 1.0
+            return raw_fine_idx.astype(float) * step
+
+    def _compute_per_tile_centroids(
+        self, rd: ResolvedDim, tile_index: list[dict[str, Any]]
+    ) -> np.ndarray:
+        fine_offsets = self._get_fine_offsets(rd)
+        out = np.empty(len(tile_index), dtype=float)
+        fine_min, fine_max = infer_bounds_from_values(fine_offsets)
+        for i, tile in enumerate(tile_index):
+            origin = to_float_ns(np.asarray([tile.get(rd.coarse_name, 0.0)]))[0]
+            out[i] = midpoint(origin + fine_min, origin + fine_max)
+        return out
+
+    def _compute_per_tile_bounds(
+        self, rd: ResolvedDim, tile_index: list[dict[str, Any]]
+    ) -> tuple[np.ndarray, np.ndarray]:
+        fine_offsets = self._get_fine_offsets(rd)
+        mins = np.empty(len(tile_index), dtype=float)
+        maxs = np.empty(len(tile_index), dtype=float)
+        fine_min, fine_max = infer_bounds_from_values(fine_offsets)
+        for i, tile in enumerate(tile_index):
+            origin = to_float_ns(np.asarray([tile.get(rd.coarse_name, 0.0)]))[0]
+            mins[i] = origin + fine_min
+            maxs[i] = origin + fine_max
+        return mins, maxs
+
+    # ------------------------------------------------------------------
+    # Private: dataset-level reprojection
+    # ------------------------------------------------------------------
+
+    def _reproject_dataset_centroids(
+        self,
+        data_vars: dict[str, xr.DataArray],
+        tile_coords: dict[str, xr.DataArray],
+        target_crs: str,
+    ) -> dict[str, xr.DataArray]:
+        if "centroid_x" not in data_vars or "centroid_y" not in data_vars:
+            return data_vars
+
+        from pyproj import Transformer
+
+        transformer = Transformer.from_crs(self._src_crs, target_crs, always_xy=True)
+        xs = data_vars["centroid_x"].values
+        ys = data_vars["centroid_y"].values
+        xs_new, ys_new = transformer.transform(xs, ys)
+
+        updated = dict(data_vars)
+        updated["centroid_x"] = xr.DataArray(xs_new, coords=tile_coords, dims=["tile"])
+        updated["centroid_y"] = xr.DataArray(ys_new, coords=tile_coords, dims=["tile"])
+        return updated
+
+    def _reproject_dataset_bounds(
+        self,
+        data_vars: dict[str, xr.DataArray],
+        tile_coords: dict[str, xr.DataArray],
+        target_crs: str,
+    ) -> dict[str, xr.DataArray]:
+        x_min_key = "bounds_x_min"
+        x_max_key = "bounds_x_max"
+        y_min_key = "bounds_y_min"
+        y_max_key = "bounds_y_max"
+
+        if not all(k in data_vars for k in (x_min_key, x_max_key, y_min_key, y_max_key)):
+            return data_vars
+
+        from pyproj import Transformer
+
+        transformer = Transformer.from_crs(self._src_crs, target_crs, always_xy=True)
+
+        x_mins = data_vars[x_min_key].values
+        x_maxs = data_vars[x_max_key].values
+        y_mins = data_vars[y_min_key].values
+        y_maxs = data_vars[y_max_key].values
+
+        # Reproject all four corners per tile
+        corners_x = np.concatenate([x_mins, x_maxs, x_maxs, x_mins])
+        corners_y = np.concatenate([y_mins, y_mins, y_maxs, y_maxs])
+        cx_new, cy_new = transformer.transform(corners_x, corners_y)
+        n = len(x_mins)
+        cx_new = cx_new.reshape(4, n)
+        cy_new = cy_new.reshape(4, n)
+
+        updated = dict(data_vars)
+        updated[x_min_key] = xr.DataArray(cx_new.min(axis=0), coords=tile_coords, dims=["tile"])
+        updated[x_max_key] = xr.DataArray(cx_new.max(axis=0), coords=tile_coords, dims=["tile"])
+        updated[y_min_key] = xr.DataArray(cy_new.min(axis=0), coords=tile_coords, dims=["tile"])
+        updated[y_max_key] = xr.DataArray(cy_new.max(axis=0), coords=tile_coords, dims=["tile"])
+        return updated
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def from_xarray(
+    obj: xr.DataArray | xr.Dataset,
+    expected: str | list[str] | None,
+    crs: str | None,
+) -> _BaseGeometry:
+    """
+    Inspect *obj* and return the appropriate geometry class instance.
+
+    This is the central dispatcher used by the public API functions.
+    """
+    src_crs = resolve_crs(obj, crs)
+
+    # If the object has no _coarse/_fine structure at all, it is a pixel.
+    # In that case validate_expected is skipped entirely (there is nothing
+    # to validate against), and we resolve raw coord aliases instead.
+    # Note: if the user passed expected= on a non-tiled object, we still
+    # honour it below via _resolve_pixel_dims so chosen/expected work.
+    if not has_tiling_structure(obj):
+        # No _coarse/_fine structure → pixel. expected= on a pixel is fine:
+        # it tells _resolve_pixel_dims which raw coordinate letters to look up.
+        # We do NOT raise here — passing expected="yx" on a lat/lon array is
+        # a normal, supported usage that selects which coords to return.
+        pixel_resolved = _resolve_pixel_dims(obj, expected)
+        return PixelGeometry(obj, pixel_resolved, src_crs)
+
+    # Object has tiling structure — validate expected and dispatch.
+    resolved = validate_expected(obj, expected)
+    obj_type = detect_object_type(obj, resolved)
+
+    if obj_type == "pixel":
+        # Has tiling coords but none matched expected — shouldn't normally
+        # reach here after validate_expected, but handle gracefully.
+        pixel_resolved = _resolve_pixel_dims(obj, expected)
+        return PixelGeometry(obj, pixel_resolved, src_crs)
+    elif obj_type == "tile":
+        return TileGeometry(obj, resolved, src_crs)
+    else:
+        return TiledArrayGeometry(obj, resolved, src_crs)
+
+
+def _resolve_pixel_dims(
+    obj: xr.DataArray | xr.Dataset,
+    expected: str | list[str] | None,
+) -> dict[str, ResolvedDim]:
+    """
+    For pixel objects (no ``_coarse`` / ``_fine`` structure), build a
+    ``ResolvedDim`` map by matching alias names directly against the
+    object's raw coordinates.
+
+    The ``coarse_name`` / ``fine_name`` fields are set to the raw coord
+    name (since there is no tiling), so ``PixelGeometry`` can use
+    ``rd.base_name`` to look up values.
+
+    When *expected* is ``None``, all known dimension aliases are searched
+    and every match is included, so that ``get_centroids(obj)`` without
+    an ``expected`` argument still returns useful coordinates.
+    """
+    letters = parse_dim_string(expected)
+    # If no expected specified, attempt to auto-discover all known dim types.
+    if not letters:
+        letters = list(DIM_ALIASES.keys())  # ["t", "z", "y", "x"]
+
+    all_names: set[str] = set(obj.coords) | set(obj.dims)
+    resolved: dict[str, ResolvedDim] = {}
+
+    for letter in letters:
+        aliases = DIM_ALIASES.get(letter, [])
+        for alias in aliases:
+            if alias in all_names:
+                resolved[letter] = ResolvedDim(
+                    letter=letter,
+                    base_name=alias,
+                    coarse_name=alias,
+                    fine_name=alias,
+                )
+                break
+
+    return resolved

--- a/src/FRAME_FM/utils/geometry_utils/geometry_utils_README.md
+++ b/src/FRAME_FM/utils/geometry_utils/geometry_utils_README.md
@@ -1,0 +1,249 @@
+# xarray_geometry
+
+Centroid and bounds extraction for tiled Xarray objects.
+
+Designed for ML data pipelines that produce tiled datasets via the
+`coarsen() → construct() → stack() → transpose()` pattern, using
+`<coord>_coarse` / `<coord>_fine` coordinate naming.
+
+---
+
+## Features
+
+- **Auto-detects object type** — single pixel, single tile, or a DataArray of many tiles
+- **Works with any tiling combination** — T, Z, Y, X or any subset
+- **Coordinate alias resolution** — `y` resolves to `lat`, `latitude`, or `y`; likewise for `x`, `t`, `z`
+- **Always infers bounds** — no need for explicit bounds coordinates; inferred from coordinate spacing
+- **Optional CRS reprojection** — reproject results to any target CRS via pyproj
+- **`expected` / `chosen` API** — validate the object's tiling structure and select which dims to return
+
+---
+
+## Installation
+
+```bash
+pip install xarray_geometry            # core (xarray + numpy)
+pip install xarray_geometry[crs]       # adds pyproj for reprojection
+pip install xarray_geometry[test]      # adds pytest + pyproj
+```
+
+---
+
+## Quick start
+
+```python
+from xarray_geometry import get_centroids, get_bounds
+```
+
+### Single tile
+
+```python
+result = get_centroids(tile_da, expected="yx", crs="EPSG:4326")
+# {'centroid': {'y': 51.5, 'x': -0.1}, 'crs': 'EPSG:4326'}
+
+result = get_bounds(tile_da, expected="yx")
+# {'bounds': {'y': (51.0, 52.0), 'x': (-0.5, 0.3)}, 'crs': 'EPSG:4326'}
+```
+
+### DataArray of tiles
+
+```python
+ds = get_centroids(tiled_da, expected="tyx", chosen="yx")
+# <xarray.Dataset>
+# Dimensions:     (tile: N)
+# Coordinates:
+#   * tile          (tile) MultiIndex
+#   - t_coarse      (tile) int64 ...
+#   - y_coarse      (tile) int64 ...
+#   - x_coarse      (tile) int64 ...
+# Data variables:
+#     centroid_y    (tile) float64 ...
+#     centroid_x    (tile) float64 ...
+# Attributes:
+#     crs:          EPSG:4326
+
+ds = get_bounds(tiled_da, expected="yx", target_crs="EPSG:3857")
+# Bounds reprojected into Web Mercator — min/max per tile
+```
+
+---
+
+## API reference
+
+### `get_centroids(obj, *, expected, chosen, crs, target_crs)`
+### `get_bounds(obj, *, expected, chosen, crs, target_crs)`
+
+Both functions share the same signature.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `obj` | `xr.DataArray` or `xr.Dataset` | The Xarray object to compute geometry for |
+| `expected` | `str` or `list[str]`, optional | Dim letters that **must** exist as tiled coords — raises `ExpectedDimsMismatchError` if not. E.g. `"tyx"` or `["t","y","x"]` |
+| `chosen` | `str` or `list[str]`, optional | Subset of `expected` dims to include in the result. Defaults to all of `expected` |
+| `crs` | `str`, optional | Source CRS of the input data. Auto-detected if not given |
+| `target_crs` | `str`, optional | Target CRS for output coordinates. Requires pyproj |
+
+**Returns:**
+- `dict` for a pixel or single tile: `{"centroid": {letter: value}, "crs": str}` / `{"bounds": {letter: (min, max)}, "crs": str}`
+- `xr.Dataset` for a tiled array: one row per tile, with coarse coords retained as index coordinates
+
+---
+
+## Supported dimension letters
+
+| Letter | Resolved aliases (in order) |
+|--------|-----------------------------|
+| `t` | `time`, `t` |
+| `z` | `z`, `depth`, `level`, `band` |
+| `y` | `y`, `lat`, `latitude` |
+| `x` | `x`, `lon`, `longitude` |
+
+For each letter, the library looks for `<alias>_coarse` and `<alias>_fine`
+coordinates in the object. The first matching alias wins.
+
+---
+
+## Coordinate naming convention
+
+Your tiled objects must use the `<coord>_coarse` / `<coord>_fine` naming
+produced by the standard Xarray tiling pipeline:
+
+```python
+tiled = (
+    da.coarsen(y=tile_size, x=tile_size, boundary="trim")
+      .construct(y="y_coarse", x="x_coarse")   # → y_coarse, y as y_fine
+      .stack(tile=("y_coarse", "x_coarse"))
+      .transpose("tile", "y", "x")
+)
+# After rename:
+# tiled = tiled.rename({"y": "y_fine", "x": "x_fine"})
+```
+
+The resulting object has:
+- A `tile` MultiIndex dimension built from `y_coarse` / `x_coarse`
+- `y_fine` / `x_fine` as the within-tile coordinate dims
+
+---
+
+## `expected` vs `chosen`
+
+```python
+# Validate that T, Y, X tiles exist — but only compute Y and X results
+get_centroids(obj, expected="tyx", chosen="yx")
+
+# Validate and return all dims
+get_centroids(obj, expected="yx")
+
+# No validation — object type is auto-detected, no tiling expected
+get_centroids(obj, crs="EPSG:4326")
+```
+
+`expected` is a **validation contract** — it asserts the object was tiled in
+these dimensions and raises loudly if not.
+
+`chosen` is a **projection** — it selects which dims appear in the result.
+It must be a subset of `expected`.
+
+---
+
+## CRS resolution
+
+The source CRS is resolved in this priority order:
+
+1. **Explicit `crs=` argument** — highest priority
+2. **Object attributes** — `obj.attrs["crs"]`, `obj.attrs["grid_mapping"]`, `obj.attrs["spatial_ref"]`, etc.
+3. **rioxarray** — `obj.rio.crs` if rioxarray is installed and attached
+4. **Coordinate name heuristic** — if both a lat-like and a lon-like coordinate name are present, assume `EPSG:4326`
+5. **Raise `CRSUnresolvableError`** — with a message explaining how to fix it
+
+---
+
+## Bounds inference
+
+Bounds are always inferred from coordinate spacing — explicit bounds
+coordinates are not required.
+
+**For a pixel** (no `_coarse` / `_fine` structure):
+- Single coordinate value → point geometry (min == max)
+- Multiple values → half-cell padding extrapolated from edge spacing
+
+**For a tile** (`_coarse` + `_fine` coordinates):
+- `_coarse` provides the tile's origin offset
+- `_fine` values give the within-tile positions
+- Total bounds = `coarse_origin + inferred_fine_bounds`
+
+**Centroid** is always the midpoint of the inferred bounds.
+
+---
+
+## Object type detection
+
+The library inspects the Xarray object to classify it automatically:
+
+| Type | How detected |
+|------|-------------|
+| `tiled_array` | Has a pandas MultiIndex dimension whose levels include a `_coarse` coordinate, OR any `_coarse` coordinate has size > 1 |
+| `tile` | Has `_coarse` coordinates, all with size == 1 |
+| `pixel` | No `_coarse` / `_fine` coordinates, or `expected=None` |
+
+---
+
+## Reprojection
+
+Pass `target_crs` to reproject results. Only x/y coordinates are
+reprojected; t and z are returned in their native units.
+
+```python
+# Single tile: centroid in Web Mercator
+result = get_centroids(tile_da, expected="yx", crs="EPSG:4326", target_crs="EPSG:3857")
+
+# Tiled array: bounds in UTM zone 30N
+ds = get_bounds(tiled_da, expected="yx", target_crs="EPSG:32630")
+```
+
+For bounds, all four corners of each tile are reprojected and the enclosing
+axis-aligned box in the target CRS is returned. This is correct for
+moderate extents; for tiles spanning large areas or crossing the antimeridian,
+consider densifying the edges before reprojection.
+
+Reprojection requires [pyproj](https://pyproj4.github.io/pyproj/):
+
+```bash
+pip install pyproj
+```
+
+---
+
+## Exceptions
+
+| Exception | When raised |
+|-----------|-------------|
+| `ExpectedDimsMismatchError` | Object doesn't have the tiled coordinates asserted in `expected` |
+| `DimNotFoundError` | Unknown dim letter, or `chosen` dim not in `expected` |
+| `CRSUnresolvableError` | CRS cannot be determined by any method |
+
+---
+
+## Running the tests
+
+```bash
+pip install xarray_geometry[test]
+pytest tests/ -v
+```
+
+The reprojection tests are automatically skipped if pyproj is not installed.
+
+---
+
+## Package structure
+
+```
+xarray_geometry/
+├── api.py          # get_centroids() / get_bounds() — public entry points
+├── geometry.py     # PixelGeometry, TileGeometry, TiledArrayGeometry, from_xarray() factory
+├── dims.py         # Dim-letter parsing, alias resolution, object-type detection
+├── inference.py    # Bounds inference math, midpoint, pyproj reprojection helpers
+├── crs.py          # 4-step CRS resolution chain
+├── constants.py    # DIM_ALIASES, suffixes, lat/lon alias sets
+└── exceptions.py   # CRSUnresolvableError, DimNotFoundError, ExpectedDimsMismatchError
+```

--- a/src/FRAME_FM/utils/geometry_utils/inference.py
+++ b/src/FRAME_FM/utils/geometry_utils/inference.py
@@ -1,0 +1,275 @@
+"""
+Bounds inference from coordinate arrays.
+
+All public functions work on raw numpy / array-like coordinate values and
+return ``(min_val, max_val)`` pairs representing the *spatial extent* of
+a tile or pixel in one dimension.
+
+Strategy (as agreed)
+---------------------
+* Centroid  = midpoint of the inferred bounds.
+* Bounds    = (min_val, max_val) inferred from coordinate spacing.
+
+For a dimension with both ``_coarse`` and ``_fine`` coordinates:
+  - ``_fine`` values give the intra-tile extent.
+  - ``_coarse`` gives the tile's origin offset.
+
+For a dimension with only one of coarse/fine (e.g. a pixel), we infer
+bounds from the coordinate value itself and its neighbours (if any), or
+treat a single scalar as a zero-width point.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Core inference
+# ---------------------------------------------------------------------------
+
+def infer_bounds_from_values(values: np.ndarray) -> tuple[float, float]:
+    """
+    Infer spatial bounds from a 1-D array of coordinate values.
+
+    For a single value, the bound is the value itself (point geometry).
+    For multiple values, the bounds are extrapolated outward by half a
+    cell from the outermost coordinate values using the edge spacing.
+
+    Parameters
+    ----------
+    values:
+        1-D coordinate values (already sorted or assumed monotonic).
+
+    Returns
+    -------
+    (min_val, max_val)
+    """
+    values = np.asarray(values, dtype=float).ravel()
+    if values.size == 0:
+        raise ValueError("Cannot infer bounds from an empty coordinate array.")
+
+    if values.size == 1:
+        return float(values[0]), float(values[0])
+
+    # Sort so min/max logic is reliable
+    sorted_vals = np.sort(values)
+    half_left = (sorted_vals[1] - sorted_vals[0]) / 2.0
+    half_right = (sorted_vals[-1] - sorted_vals[-2]) / 2.0
+
+    return float(sorted_vals[0] - half_left), float(sorted_vals[-1] + half_right)
+
+
+def infer_bounds_coarse_fine(
+    coarse_values: np.ndarray,
+    fine_values: np.ndarray,
+) -> tuple[float, float]:
+    """
+    Infer the *global* spatial bounds for a single tile given its coarse
+    origin coordinate and fine intra-tile coordinates.
+
+    The coarse coordinate locates the tile; the fine coordinates describe
+    its internal grid.  Together they define the tile's full extent:
+
+        global_coord = coarse_origin + fine_offset
+
+    For the single-tile case (one coarse value), we add the coarse origin
+    to the fine extent.  The fine bounds are inferred via
+    :func:`infer_bounds_from_values`.
+
+    Parameters
+    ----------
+    coarse_values:
+        Coarse coordinate values for *this tile* (often a scalar or 1-element
+        array representing the tile origin).
+    fine_values:
+        Fine coordinate values spanning the tile interior.
+
+    Returns
+    -------
+    (min_val, max_val)
+    """
+    coarse_values = np.asarray(coarse_values, dtype=float).ravel()
+    fine_values = np.asarray(fine_values, dtype=float).ravel()
+
+    fine_min, fine_max = infer_bounds_from_values(fine_values)
+
+    if coarse_values.size == 1:
+        origin = float(coarse_values[0])
+        return origin + fine_min, origin + fine_max
+
+    # Multiple coarse values — this is a tiled array slice; return the
+    # global extent across all tiles.
+    coarse_min, coarse_max = infer_bounds_from_values(coarse_values)
+    # Total extent = coarse span + fine span on each edge
+    fine_span_half = (fine_max - fine_min) / 2.0
+    return coarse_min + fine_min - fine_span_half, coarse_max + fine_max + fine_span_half
+
+
+def infer_pixel_bounds(values: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Infer per-pixel spatial bounds from a 1-D array of coordinate values.
+
+    Each pixel's bounds extend halfway to its neighbours.  Edge pixels use
+    the same half-step as their single neighbour.
+
+    Parameters
+    ----------
+    values:
+        1-D coordinate values in native order (need not be sorted).
+
+    Returns
+    -------
+    (mins, maxs)
+        Two float64 arrays of the same length as *values*.
+    """
+    vals = np.asarray(values, dtype=float).ravel()
+    n = vals.size
+    if n == 0:
+        raise ValueError("Cannot infer pixel bounds from an empty coordinate array.")
+
+    mins = np.empty(n, dtype=float)
+    maxs = np.empty(n, dtype=float)
+
+    if n == 1:
+        mins[0] = maxs[0] = float(vals[0])
+        return mins, maxs
+
+    # Half-step to each neighbour; edges extrapolate from the single neighbour.
+    half = np.diff(vals) / 2.0          # length n-1
+    left_half = np.empty(n, dtype=float)
+    right_half = np.empty(n, dtype=float)
+
+    left_half[0]    = half[0]           # extrapolate at left edge
+    left_half[1:]   = half              # step back from each interior/right point
+    right_half[:-1] = half              # step forward from each interior/left point
+    right_half[-1]  = half[-1]          # extrapolate at right edge
+
+    mins = vals - left_half
+    maxs = vals + right_half
+    return mins, maxs
+
+
+
+    """Return True if *values* has a datetime64 or timedelta64 dtype."""
+    return np.issubdtype(values.dtype, np.datetime64) or np.issubdtype(
+        values.dtype, np.timedelta64
+    )
+
+
+def to_float_ns(values: np.ndarray) -> np.ndarray:
+    """
+    Cast coord values to float64 for arithmetic, preserving datetime64 as
+    nanoseconds-since-epoch.
+
+    Handles three cases:
+    - numpy datetime64 arrays (from xr.DataArray.values)
+    - object arrays whose elements are pandas Timestamps (from MultiIndex iteration)
+    - plain numeric arrays
+    """
+    arr = np.asarray(values)
+
+    if np.issubdtype(arr.dtype, np.datetime64):
+        return arr.astype("datetime64[ns]").astype(np.float64)
+
+    # Object array — elements may be pd.Timestamp or np.datetime64 scalars
+    if arr.dtype == object and arr.size > 0:
+        import pandas as pd
+        first = arr.ravel()[0]
+        if isinstance(first, (pd.Timestamp, np.datetime64)):
+            return np.array(
+                [pd.Timestamp(v).value for v in arr.ravel()], dtype=np.float64
+            )
+
+    return np.asarray(arr, dtype=float)
+
+
+def from_float_ns(value: float, ref_dtype: np.dtype) -> Any:
+    """
+    Convert a float nanoseconds value back to the original dtype.
+
+    For datetime64 dtypes this returns a ``numpy.datetime64``; for numeric
+    dtypes it returns the plain float.
+    """
+    if np.issubdtype(ref_dtype, np.datetime64):
+        return np.datetime64(int(value), "ns")
+    return value
+
+
+def bounds_to_native(
+    mn: float, mx: float, ref_dtype: np.dtype
+) -> tuple[Any, Any]:
+    """Return (min, max) in the original coord dtype."""
+    return from_float_ns(mn, ref_dtype), from_float_ns(mx, ref_dtype)
+
+
+def centroid_to_native(value: float, ref_dtype: np.dtype) -> Any:
+    """Return the centroid value in the original coord dtype."""
+    return from_float_ns(value, ref_dtype)
+
+
+def midpoint(min_val: float, max_val: float) -> float:
+    """Return the midpoint of a (min, max) bounds pair."""
+    return (min_val + max_val) / 2.0
+
+
+# ---------------------------------------------------------------------------
+# CRS-aware reprojection of a single point or bounds
+# ---------------------------------------------------------------------------
+
+def reproject_point(
+    x: float,
+    y: float,
+    src_crs: str,
+    dst_crs: str,
+) -> tuple[float, float]:
+    """
+    Reproject a single (x, y) point from *src_crs* to *dst_crs*.
+
+    Returns
+    -------
+    (x_dst, y_dst)
+    """
+    from pyproj import Transformer
+
+    transformer = Transformer.from_crs(src_crs, dst_crs, always_xy=True)
+    x_dst, y_dst = transformer.transform(x, y)
+    return float(x_dst), float(y_dst)
+
+
+def reproject_bounds(
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+    src_crs: str,
+    dst_crs: str,
+) -> tuple[float, float, float, float]:
+    """
+    Reproject a bounding box from *src_crs* to *dst_crs*.
+
+    Reprojects all four corners and returns the enclosing axis-aligned box
+    in the target CRS.  This is correct for moderate extents; for very large
+    tiles crossing datum discontinuities callers should densify the edges.
+
+    Returns
+    -------
+    (min_x, min_y, max_x, max_y) in *dst_crs*
+    """
+    from pyproj import Transformer
+
+    transformer = Transformer.from_crs(src_crs, dst_crs, always_xy=True)
+
+    corners_src = [
+        (min_x, min_y),
+        (max_x, min_y),
+        (max_x, max_y),
+        (min_x, max_y),
+    ]
+    xs, ys = transformer.transform(
+        [c[0] for c in corners_src],
+        [c[1] for c in corners_src],
+    )
+    return float(min(xs)), float(min(ys)), float(max(xs)), float(max(ys))

--- a/tests/geometry/test_geometry_utils.py
+++ b/tests/geometry/test_geometry_utils.py
@@ -1,0 +1,1289 @@
+"""
+Tests for xarray_geometry.
+
+Covers:
+  - PixelGeometry         (single pixel, lat/lon and projected)
+  - TileGeometry          (single tile, various coarse offsets and fine grids)
+  - TiledArrayGeometry    (YX, TYX, ZYX, TZYX combinations; MultiIndex and non-MultiIndex)
+  - expected / chosen     (validation contract, subset selection, error paths)
+  - CRS resolution        (explicit > attrs > rioxarray > heuristic > error)
+  - Reprojection          (point, bounds, dataset-level; identity transform)
+  - Inference helpers     (bounds, midpoint, coarse+fine math)
+  - Dim parsing           (string, list, case, whitespace, unknown letter)
+  - Object-type detection (pixel/tile/tiled_array discriminator)
+  - xr.Dataset input      (not just DataArray)
+  - Edge cases            (1×1 tile grid, negative coordinates, large step sizes)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from FRAME_FM.utils.geometry_utils import get_bounds, get_centroids
+from FRAME_FM.utils.geometry_utils.dims import (
+    detect_object_type,
+    parse_dim_string,
+    resolve_dims,
+    validate_expected,
+)
+from FRAME_FM.utils.geometry_utils.exceptions import (
+    CRSUnresolvableError,
+    DimNotFoundError,
+    ExpectedDimsMismatchError,
+)
+from FRAME_FM.utils.geometry_utils.inference import (
+    infer_bounds_coarse_fine,
+    infer_bounds_from_values,
+    midpoint,
+)
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+def make_pixel(lat: float = 51.5, lon: float = -0.1, crs: str | None = "EPSG:4326") -> xr.DataArray:
+    """Single-pixel DataArray with lat/lon coords."""
+    da = xr.DataArray(
+        [[1.0]],
+        dims=["latitude", "longitude"],
+        coords={"latitude": [lat], "longitude": [lon]},
+    )
+    if crs:
+        da.attrs["crs"] = crs
+    return da
+
+
+def make_single_tile(
+    y_coarse: float = 0.0,
+    x_coarse: float = 0.0,
+    fine_steps: int = 4,
+    crs: str = "EPSG:4326",
+) -> xr.DataArray:
+    """
+    DataArray representing a single tile using the _coarse/_fine convention.
+    Fine values span [0, fine_steps - 1]; coarse locates the tile origin.
+    """
+    fine_y = np.arange(fine_steps, dtype=float)
+    fine_x = np.arange(fine_steps, dtype=float)
+    data = np.ones((fine_steps, fine_steps))
+    da = xr.DataArray(
+        data,
+        dims=["y_fine", "x_fine"],
+        coords={
+            "y_fine": fine_y,
+            "x_fine": fine_x,
+            "y_coarse": y_coarse,
+            "x_coarse": x_coarse,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+def make_tiled_array(
+    n_y: int = 3,
+    n_x: int = 3,
+    fine_steps: int = 4,
+    step_size: float = 10.0,
+    crs: str = "EPSG:4326",
+) -> xr.DataArray:
+    """
+    Simulate the coarsen() -> construct() -> stack() -> transpose() output.
+
+    Creates an (n_y * n_x) tiled DataArray with a MultiIndex 'tile' dim
+    built from y_coarse and x_coarse.
+    """
+    fine_y = np.arange(fine_steps, dtype=float)
+    fine_x = np.arange(fine_steps, dtype=float)
+    coarse_y = np.arange(n_y, dtype=float) * step_size
+    coarse_x = np.arange(n_x, dtype=float) * step_size
+
+    n_tiles = n_y * n_x
+    data = np.random.rand(n_tiles, fine_steps, fine_steps)
+
+    # Build MultiIndex
+    tile_index = pd.MultiIndex.from_product(
+        [coarse_y, coarse_x], names=["y_coarse", "x_coarse"]
+    )
+    tile_coord = xr.Coordinates.from_pandas_multiindex(tile_index, "tile")
+
+    da = xr.DataArray(
+        data,
+        dims=["tile", "y_fine", "x_fine"],
+        coords={
+            **tile_coord,
+            "y_fine": fine_y,
+            "x_fine": fine_x,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+def make_tiled_array_zyx(
+    n_z: int = 2,
+    n_y: int = 2,
+    n_x: int = 2,
+    fine_steps: int = 3,
+    step_size: float = 5.0,
+    crs: str = "EPSG:4326",
+) -> xr.DataArray:
+    """Tiled array with Z, Y, X coarse dims (MultiIndex).
+
+    z_fine and the spatial fine coords are added as dimension coordinates.
+    The data array has dims (tile, z_fine, y_fine, x_fine).
+    """
+    fine_vals = np.arange(fine_steps, dtype=float)
+    coarse_z = np.arange(n_z, dtype=float) * step_size
+    coarse_y = np.arange(n_y, dtype=float) * step_size
+    coarse_x = np.arange(n_x, dtype=float) * step_size
+
+    n_tiles = n_z * n_y * n_x
+    data = np.random.rand(n_tiles, fine_steps, fine_steps, fine_steps)
+
+    tile_index = pd.MultiIndex.from_product(
+        [coarse_z, coarse_y, coarse_x], names=["z_coarse", "y_coarse", "x_coarse"]
+    )
+    tile_coord = xr.Coordinates.from_pandas_multiindex(tile_index, "tile")
+
+    da = xr.DataArray(
+        data,
+        dims=["tile", "z_fine", "y_fine", "x_fine"],
+        coords={
+            **tile_coord,
+            "z_fine": fine_vals,
+            "y_fine": fine_vals,
+            "x_fine": fine_vals,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+def make_tiled_array_tzyx(
+    n_t: int = 2,
+    n_z: int = 2,
+    n_y: int = 2,
+    n_x: int = 2,
+    fine_steps: int = 3,
+    step_size: float = 5.0,
+    crs: str = "EPSG:4326",
+) -> xr.DataArray:
+    """Tiled array with T, Z, Y, X coarse dims (MultiIndex) — full TZYX case.
+
+    All four fine dimensions (t_fine, z_fine, y_fine, x_fine) are present.
+    """
+    fine_vals = np.arange(fine_steps, dtype=float)
+    coarse_t = np.arange(n_t, dtype=float)
+    coarse_z = np.arange(n_z, dtype=float) * step_size
+    coarse_y = np.arange(n_y, dtype=float) * step_size
+    coarse_x = np.arange(n_x, dtype=float) * step_size
+
+    n_tiles = n_t * n_z * n_y * n_x
+    # data: (tile, t_fine, z_fine, y_fine, x_fine) — use 2 fine dims for brevity
+    data = np.random.rand(n_tiles, fine_steps, fine_steps, fine_steps, fine_steps)
+
+    tile_index = pd.MultiIndex.from_product(
+        [coarse_t, coarse_z, coarse_y, coarse_x],
+        names=["t_coarse", "z_coarse", "y_coarse", "x_coarse"],
+    )
+    tile_coord = xr.Coordinates.from_pandas_multiindex(tile_index, "tile")
+
+    da = xr.DataArray(
+        data,
+        dims=["tile", "t_fine", "z_fine", "y_fine", "x_fine"],
+        coords={
+            **tile_coord,
+            "t_fine": fine_vals,
+            "z_fine": fine_vals,
+            "y_fine": fine_vals,
+            "x_fine": fine_vals,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+def make_single_tile_latlon(
+    lat_coarse: float = 51.0,
+    lon_coarse: float = -1.0,
+    fine_steps: int = 4,
+    crs: str = "EPSG:4326",
+) -> xr.DataArray:
+    """Single tile using lat/lon alias names instead of y/x."""
+    fine_lat = np.arange(fine_steps, dtype=float) * 0.1
+    fine_lon = np.arange(fine_steps, dtype=float) * 0.1
+    data = np.ones((fine_steps, fine_steps))
+    da = xr.DataArray(
+        data,
+        dims=["lat_fine", "lon_fine"],
+        coords={
+            "lat_fine": fine_lat,
+            "lon_fine": fine_lon,
+            "lat_coarse": lat_coarse,
+            "lon_coarse": lon_coarse,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+def make_single_tile_negative_coords(crs: str = "EPSG:4326") -> xr.DataArray:
+    """Single tile with negative coarse coordinates (southern/western hemisphere)."""
+    fine_y = np.arange(4, dtype=float)
+    fine_x = np.arange(4, dtype=float)
+    data = np.ones((4, 4))
+    da = xr.DataArray(
+        data,
+        dims=["y_fine", "x_fine"],
+        coords={
+            "y_fine": fine_y,
+            "x_fine": fine_x,
+            "y_coarse": -40.0,
+            "x_coarse": -75.0,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+def make_dataset_single_tile(crs: str = "EPSG:4326") -> xr.Dataset:
+    """xr.Dataset (not DataArray) representing a single tile."""
+    da = make_single_tile(crs=crs)
+    return da.to_dataset(name="values")
+
+
+def make_tiled_array_non_multiindex(
+    n_y: int = 3,
+    n_x: int = 3,
+    fine_steps: int = 4,
+    step_size: float = 10.0,
+    crs: str = "EPSG:4326",
+) -> xr.DataArray:
+    """
+    Tiled array WITHOUT a MultiIndex — uses separate coarse coordinate dims.
+    Tests the fallback path in TiledArrayGeometry._index_from_coarse_coords().
+    """
+    fine_y = np.arange(fine_steps, dtype=float)
+    fine_x = np.arange(fine_steps, dtype=float)
+    coarse_y = np.arange(n_y, dtype=float) * step_size
+    coarse_x = np.arange(n_x, dtype=float) * step_size
+    data = np.random.rand(n_y, n_x, fine_steps, fine_steps)
+    da = xr.DataArray(
+        data,
+        dims=["y_coarse", "x_coarse", "y_fine", "x_fine"],
+        coords={
+            "y_coarse": coarse_y,
+            "x_coarse": coarse_x,
+            "y_fine": fine_y,
+            "x_fine": fine_x,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+# ===========================================================================
+# Unit tests: inference helpers
+# ===========================================================================
+
+class TestInferBoundsFromValues:
+    def test_single_value_returns_point(self):
+        mn, mx = infer_bounds_from_values(np.array([5.0]))
+        assert mn == mx == 5.0
+
+    def test_two_values_symmetric(self):
+        mn, mx = infer_bounds_from_values(np.array([0.0, 2.0]))
+        assert mn == pytest.approx(-1.0)
+        assert mx == pytest.approx(3.0)
+
+    def test_uniform_grid(self):
+        vals = np.arange(5, dtype=float)  # 0 1 2 3 4, spacing=1
+        mn, mx = infer_bounds_from_values(vals)
+        assert mn == pytest.approx(-0.5)
+        assert mx == pytest.approx(4.5)
+
+    def test_unsorted_input(self):
+        mn, mx = infer_bounds_from_values(np.array([4.0, 0.0, 2.0]))
+        assert mn < mx
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            infer_bounds_from_values(np.array([]))
+
+
+class TestMidpoint:
+    def test_basic(self):
+        assert midpoint(0.0, 10.0) == pytest.approx(5.0)
+
+    def test_negative(self):
+        assert midpoint(-3.0, 3.0) == pytest.approx(0.0)
+
+    def test_same_value(self):
+        assert midpoint(7.0, 7.0) == pytest.approx(7.0)
+
+
+class TestInferBoundsCoarseFine:
+    def test_single_coarse_zero_offset(self):
+        # Coarse=0, fine=[0,1,2,3] → bounds should be (-0.5, 3.5)
+        mn, mx = infer_bounds_coarse_fine(
+            np.array([0.0]), np.arange(4, dtype=float)
+        )
+        assert mn == pytest.approx(-0.5)
+        assert mx == pytest.approx(3.5)
+
+    def test_single_coarse_nonzero_offset(self):
+        # Coarse=10, fine=[0,1,2,3] → bounds should be (9.5, 13.5)
+        mn, mx = infer_bounds_coarse_fine(
+            np.array([10.0]), np.arange(4, dtype=float)
+        )
+        assert mn == pytest.approx(9.5)
+        assert mx == pytest.approx(13.5)
+
+    def test_centroid_is_midpoint(self):
+        mn, mx = infer_bounds_coarse_fine(
+            np.array([0.0]), np.arange(4, dtype=float)
+        )
+        assert midpoint(mn, mx) == pytest.approx(1.5)
+
+
+# ===========================================================================
+# PixelGeometry
+# ===========================================================================
+
+class TestPixelGeometry:
+    def test_centroid_returns_dict(self):
+        da = make_pixel()
+        result = get_centroids(da, expected="yx", crs="EPSG:4326", by="tile")
+        assert isinstance(result, dict)
+        assert "centroid" in result
+        assert "y" in result["centroid"]
+        assert "x" in result["centroid"]
+
+    def test_centroid_values(self):
+        da = make_pixel(lat=51.5, lon=-0.1)
+        result = get_centroids(da, expected="yx", crs="EPSG:4326", by="tile")
+        assert result["centroid"]["y"] == pytest.approx(51.5)
+        assert result["centroid"]["x"] == pytest.approx(-0.1)
+
+    def test_bounds_returns_dict(self):
+        da = make_pixel()
+        result = get_bounds(da, expected="yx", crs="EPSG:4326", by="tile")
+        assert "bounds" in result
+        assert "y" in result["bounds"]
+        assert "x" in result["bounds"]
+
+    def test_bounds_point_geometry(self):
+        # Single pixel → bounds collapse to point
+        da = make_pixel(lat=10.0, lon=20.0)
+        result = get_bounds(da, expected="yx", crs="EPSG:4326", by="tile")
+        y_min, y_max = result["bounds"]["y"]
+        x_min, x_max = result["bounds"]["x"]
+        assert y_min == y_max == pytest.approx(10.0)
+        assert x_min == x_max == pytest.approx(20.0)
+
+    def test_crs_in_result(self):
+        da = make_pixel()
+        result = get_centroids(da, expected="yx", crs="EPSG:4326", by="tile")
+        assert result["crs"] == "EPSG:4326"
+
+    def test_chosen_subset(self):
+        da = make_pixel()
+        result = get_centroids(da, expected="yx", chosen="y", crs="EPSG:4326", by="tile")
+        assert "y" in result["centroid"]
+        assert "x" not in result["centroid"]
+
+    def test_chosen_x_only(self):
+        da = make_pixel()
+        result = get_centroids(da, expected="yx", chosen="x", crs="EPSG:4326", by="tile")
+        assert "x" in result["centroid"]
+        assert "y" not in result["centroid"]
+
+
+# ===========================================================================
+# TileGeometry
+# ===========================================================================
+
+class TestTileGeometry:
+    def test_centroid_returns_dict(self):
+        da = make_single_tile()
+        result = get_centroids(da, expected="yx", by="tile")
+        assert isinstance(result, dict)
+        assert "centroid" in result
+
+    def test_centroid_y_x_values(self):
+        # y_coarse=0, x_coarse=0, fine=[0,1,2,3]
+        # centroid_y = midpoint(-0.5, 3.5) = 1.5
+        # centroid_x = midpoint(-0.5, 3.5) = 1.5
+        da = make_single_tile(y_coarse=0.0, x_coarse=0.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["centroid"]["y"] == pytest.approx(1.5)
+        assert result["centroid"]["x"] == pytest.approx(1.5)
+
+    def test_centroid_with_offset(self):
+        # y_coarse=10, x_coarse=20, fine=[0,1,2,3]
+        # centroid_y = midpoint(9.5, 13.5) = 11.5
+        da = make_single_tile(y_coarse=10.0, x_coarse=20.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["centroid"]["y"] == pytest.approx(11.5)
+        assert result["centroid"]["x"] == pytest.approx(21.5)
+
+    def test_bounds_values(self):
+        da = make_single_tile(y_coarse=0.0, x_coarse=0.0, fine_steps=4)
+        result = get_bounds(da, expected="yx", by="tile")
+        y_min, y_max = result["bounds"]["y"]
+        assert y_min == pytest.approx(-0.5)
+        assert y_max == pytest.approx(3.5)
+
+    def test_chosen_y_only(self):
+        da = make_single_tile()
+        result = get_centroids(da, expected="yx", chosen="y", by="tile")
+        assert "y" in result["centroid"]
+        assert "x" not in result["centroid"]
+
+    def test_chosen_x_only_bounds(self):
+        da = make_single_tile()
+        result = get_bounds(da, expected="yx", chosen="x", by="tile")
+        assert "x" in result["bounds"]
+        assert "y" not in result["bounds"]
+
+    def test_crs_from_attrs(self):
+        da = make_single_tile(crs="EPSG:32633")
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["crs"] == "EPSG:32633"
+
+
+# ===========================================================================
+# TiledArrayGeometry
+# ===========================================================================
+
+class TestTiledArrayGeometry:
+    def test_centroid_returns_dataset(self):
+        da = make_tiled_array(n_y=3, n_x=3)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert isinstance(result, xr.Dataset)
+
+    def test_centroid_has_correct_variables(self):
+        da = make_tiled_array(n_y=2, n_x=2)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert "centroid_y" in result
+        assert "centroid_x" in result
+
+    def test_centroid_tile_count(self):
+        da = make_tiled_array(n_y=3, n_x=4)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result.sizes["tile"] == 12
+
+    def test_bounds_returns_dataset(self):
+        da = make_tiled_array(n_y=2, n_x=2)
+        result = get_bounds(da, expected="yx", by="tile")
+        assert isinstance(result, xr.Dataset)
+
+    def test_bounds_has_correct_variables(self):
+        da = make_tiled_array(n_y=2, n_x=2)
+        result = get_bounds(da, expected="yx", by="tile")
+        assert "bounds_y_min" in result
+        assert "bounds_y_max" in result
+        assert "bounds_x_min" in result
+        assert "bounds_x_max" in result
+
+    def test_bounds_min_less_than_max(self):
+        da = make_tiled_array(n_y=3, n_x=3, fine_steps=4)
+        result = get_bounds(da, expected="yx", by="tile")
+        assert (result["bounds_y_min"].values <= result["bounds_y_max"].values).all()
+        assert (result["bounds_x_min"].values <= result["bounds_x_max"].values).all()
+
+    def test_crs_in_dataset_attrs(self):
+        da = make_tiled_array(crs="EPSG:4326")
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result.attrs["crs"] == "EPSG:4326"
+
+    def test_chosen_y_only(self):
+        da = make_tiled_array(n_y=2, n_x=2)
+        result = get_centroids(da, expected="yx", chosen="y", by="tile")
+        assert "centroid_y" in result
+        assert "centroid_x" not in result
+
+    def test_chosen_x_only_bounds(self):
+        da = make_tiled_array(n_y=2, n_x=2)
+        result = get_bounds(da, expected="yx", chosen="x", by="tile")
+        assert "bounds_x_min" in result
+        assert "bounds_y_min" not in result
+
+    def test_tyx_expected_chosen_yx(self):
+        da = make_tiled_array_tzyx(n_t=2, n_z=1, n_y=2, n_x=2)
+        result = get_centroids(da, expected="tzyx", chosen="yx", by="tile")
+        assert "centroid_y" in result
+        assert "centroid_x" in result
+        assert "centroid_t" not in result
+
+    def test_tyx_tile_count(self):
+        da = make_tiled_array_tzyx(n_t=2, n_z=1, n_y=3, n_x=4)
+        result = get_centroids(da, expected="tzyx", chosen="yx", by="tile")
+        assert result.sizes["tile"] == 24
+
+    def test_coarse_coords_retained_in_output(self):
+        da = make_tiled_array(n_y=2, n_x=2)
+        result = get_centroids(da, expected="yx", by="tile")
+        # Coarse coords should be present to keep tiles addressable
+        assert "y_coarse" in result.coords or "x_coarse" in result.coords
+
+    def test_centroid_monotonic_with_coarse(self):
+        """Centroids should increase monotonically as coarse indices increase."""
+        da = make_tiled_array(n_y=4, n_x=1, fine_steps=4, step_size=10.0)
+        result = get_centroids(da, expected="yx", chosen="y", by="tile")
+        centroids = result["centroid_y"].values
+        assert np.all(np.diff(centroids) > 0), "centroids should be strictly increasing"
+
+
+# ===========================================================================
+# expected / chosen validation
+# ===========================================================================
+
+class TestExpectedChosen:
+    def test_expected_mismatch_raises(self):
+        da = make_single_tile()  # has y_coarse/x_coarse, no z
+        with pytest.raises(ExpectedDimsMismatchError):
+            get_centroids(da, expected="zyx", by="tile")
+
+    def test_chosen_not_in_expected_raises(self):
+        da = make_single_tile()
+        with pytest.raises(DimNotFoundError):
+            get_centroids(da, expected="yx", chosen="t", by="tile")
+
+    def test_expected_none_no_error(self):
+        # With no expected, the dispatcher still works (falls through to pixel)
+        da = make_pixel()
+        # No exception; type detected as pixel with empty resolved dims
+        result = get_centroids(da, crs="EPSG:4326", by="tile")
+        assert isinstance(result, dict)
+
+    def test_expected_list_form(self):
+        da = make_single_tile()
+        result = get_centroids(da, expected=["y", "x"], by="tile")
+        assert "y" in result["centroid"]
+
+    def test_chosen_list_form(self):
+        da = make_single_tile()
+        result = get_centroids(da, expected=["y", "x"], chosen=["y"], by="tile")
+        assert "y" in result["centroid"]
+        assert "x" not in result["centroid"]
+
+    def test_expected_string_case_insensitive(self):
+        da = make_single_tile()
+        result = get_centroids(da, expected="YX", by="tile")
+        assert "y" in result["centroid"]
+
+
+# ===========================================================================
+# CRS resolution
+# ===========================================================================
+
+class TestCRSResolution:
+    def test_explicit_crs_wins(self):
+        da = make_pixel()
+        da.attrs["crs"] = "EPSG:32633"
+        result = get_centroids(da, expected="yx", crs="EPSG:4326", by="tile")
+        assert result["crs"] == "EPSG:4326"
+
+    def test_attrs_crs_used(self):
+        da = make_pixel()
+        da.attrs["crs"] = "EPSG:32633"
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["crs"] == "EPSG:32633"
+
+    def test_latlon_heuristic(self):
+        da = make_pixel()
+        del da.attrs["crs"]
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["crs"] == "EPSG:4326"
+
+    def test_no_crs_raises(self):
+        # Object with non-lat/lon names and no attrs
+        da = xr.DataArray(
+            [[1.0]],
+            dims=["northing", "easting"],
+            coords={"northing": [500000.0], "easting": [300000.0]},
+        )
+        with pytest.raises(CRSUnresolvableError):
+            get_centroids(da, crs=None, by="tile")
+
+    def test_grid_mapping_attr(self):
+        da = make_pixel()
+        del da.attrs["crs"]
+        da.attrs["grid_mapping"] = "EPSG:3857"
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["crs"] == "EPSG:3857"
+
+
+# ===========================================================================
+# Reprojection (requires pyproj)
+# ===========================================================================
+
+class TestReprojection:
+    pytest.importorskip("pyproj")
+
+    def test_tile_centroid_reprojection(self):
+        """Centroid in EPSG:4326 reprojected to EPSG:3857."""
+        # y_coarse=51, fine=[0,1,2,3] → centroid_y ≈ 51+1.5 = 52.5° lat
+        # x_coarse=0,  fine=[0,1,2,3] → centroid_x ≈ 1.5° lon → ~167 000 m in 3857
+        da = make_single_tile(y_coarse=51.0, x_coarse=0.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", crs="EPSG:4326", target_crs="EPSG:3857", by="tile")
+        # y should be well above 5 million (northern hemisphere)
+        assert result["centroid"]["y"] > 5_000_000
+        # x should be a small positive number (near prime meridian)
+        assert 0 < result["centroid"]["x"] < 500_000
+        assert result["crs"] == "EPSG:3857"
+
+    def test_tiled_array_centroid_reprojection(self):
+        da = make_tiled_array(n_y=2, n_x=2, fine_steps=4, step_size=1.0, crs="EPSG:4326")
+        result = get_centroids(da, expected="yx", target_crs="EPSG:3857", by="tile")
+        assert result.attrs["crs"] == "EPSG:3857"
+        # Values should be in metre range for Web Mercator
+        assert result["centroid_x"].values.max() < 20_000_000
+
+    def test_tiled_array_bounds_reprojection(self):
+        da = make_tiled_array(n_y=2, n_x=2, fine_steps=4, step_size=1.0, crs="EPSG:4326")
+        result = get_bounds(da, expected="yx", target_crs="EPSG:3857", by="tile")
+        assert result.attrs["crs"] == "EPSG:3857"
+        assert (result["bounds_x_min"].values < result["bounds_x_max"].values).all()
+
+    def test_same_crs_no_change(self):
+        da = make_single_tile(y_coarse=0.0, x_coarse=0.0)
+        r1 = get_centroids(da, expected="yx", crs="EPSG:4326", by="tile")
+        r2 = get_centroids(da, expected="yx", crs="EPSG:4326", target_crs="EPSG:4326", by="tile")
+        assert r1["centroid"]["y"] == pytest.approx(r2["centroid"]["y"])
+        assert r1["centroid"]["x"] == pytest.approx(r2["centroid"]["x"])
+
+    def test_pixel_centroid_reprojection(self):
+        """Pixel centroid reprojects correctly — no expected needed for pixels."""
+        da = make_pixel(lat=48.8566, lon=2.3522)  # Paris
+        result = get_centroids(da, crs="EPSG:4326", target_crs="EPSG:3857", by="tile")
+        # Paris in Web Mercator: x ≈ 261_848, y ≈ 6_218_434
+        assert result["centroid"]["x"] == pytest.approx(261_848, rel=0.01)
+        assert result["centroid"]["y"] == pytest.approx(6_218_434, rel=0.01)
+
+    def test_pixel_bounds_reprojection(self):
+        """Pixel bounds reproject correctly — no expected needed for pixels."""
+        da = make_pixel(lat=51.5, lon=-0.1)
+        result = get_bounds(da, crs="EPSG:4326", target_crs="EPSG:3857", by="tile")
+        assert result["crs"] == "EPSG:3857"
+
+    def test_reprojection_preserves_tile_count(self):
+        da = make_tiled_array(n_y=3, n_x=3, crs="EPSG:4326")
+        result = get_centroids(da, expected="yx", target_crs="EPSG:3857", by="tile")
+        assert result.sizes["tile"] == 9
+
+
+# ===========================================================================
+# Dim string parsing
+# ===========================================================================
+
+class TestParseDimString:
+    def test_string_tyx(self):
+        assert parse_dim_string("tyx") == ["t", "y", "x"]
+
+    def test_string_uppercase(self):
+        assert parse_dim_string("TYX") == ["t", "y", "x"]
+
+    def test_string_with_spaces(self):
+        assert parse_dim_string("t y x") == ["t", "y", "x"]
+
+    def test_list_input(self):
+        assert parse_dim_string(["t", "y", "x"]) == ["t", "y", "x"]
+
+    def test_list_uppercase(self):
+        assert parse_dim_string(["T", "Y", "X"]) == ["t", "y", "x"]
+
+    def test_none_returns_empty(self):
+        assert parse_dim_string(None) == []
+
+    def test_empty_string(self):
+        assert parse_dim_string("") == []
+
+    def test_single_letter(self):
+        assert parse_dim_string("y") == ["y"]
+
+    def test_all_four(self):
+        assert parse_dim_string("tzyx") == ["t", "z", "y", "x"]
+
+
+# ===========================================================================
+# resolve_dims — alias matching
+# ===========================================================================
+
+class TestResolveDims:
+    def test_resolves_y_via_lat_alias(self):
+        da = make_single_tile_latlon()
+        resolved = resolve_dims(da, ["y", "x"])
+        assert "y" in resolved
+        assert resolved["y"].base_name == "lat"
+        assert resolved["y"].coarse_name == "lat_coarse"
+        assert resolved["y"].fine_name == "lat_fine"
+
+    def test_resolves_x_via_lon_alias(self):
+        da = make_single_tile_latlon()
+        resolved = resolve_dims(da, ["x"])
+        assert resolved["x"].base_name == "lon"
+
+    def test_resolves_y_via_y_name(self):
+        da = make_single_tile()
+        resolved = resolve_dims(da, ["y"])
+        assert resolved["y"].base_name == "y"
+
+    def test_unknown_letter_raises(self):
+        da = make_single_tile()
+        with pytest.raises(DimNotFoundError, match="Unknown dimension letter"):
+            resolve_dims(da, ["q"])
+
+    def test_missing_coarse_raises_strict(self):
+        da = make_single_tile()  # no z_coarse/z_fine
+        with pytest.raises(DimNotFoundError):
+            resolve_dims(da, ["z"], strict=True)
+
+    def test_missing_dim_skipped_non_strict(self):
+        da = make_single_tile()
+        resolved = resolve_dims(da, ["z", "y", "x"], strict=False)
+        assert "z" not in resolved
+        assert "y" in resolved
+        assert "x" in resolved
+
+    def test_resolved_dim_repr(self):
+        da = make_single_tile()
+        resolved = resolve_dims(da, ["y"])
+        r = repr(resolved["y"])
+        assert "letter='y'" in r
+        assert "coarse='y_coarse'" in r
+
+
+# ===========================================================================
+# detect_object_type
+# ===========================================================================
+
+class TestDetectObjectType:
+    def test_pixel_empty_resolved(self):
+        da = make_pixel()
+        assert detect_object_type(da, {}) == "pixel"
+
+    def test_tile_detected(self):
+        da = make_single_tile()
+        resolved = resolve_dims(da, ["y", "x"])
+        assert detect_object_type(da, resolved) == "tile"
+
+    def test_tiled_array_via_multiindex(self):
+        da = make_tiled_array(n_y=2, n_x=2)
+        resolved = resolve_dims(da, ["y", "x"])
+        assert detect_object_type(da, resolved) == "tiled_array"
+
+    def test_tiled_array_via_coarse_size(self):
+        da = make_tiled_array_non_multiindex(n_y=2, n_x=2)
+        resolved = resolve_dims(da, ["y", "x"])
+        assert detect_object_type(da, resolved) == "tiled_array"
+
+    def test_tzyx_tiled_array(self):
+        da = make_tiled_array_tzyx(n_t=2, n_z=2, n_y=2, n_x=2)
+        resolved = resolve_dims(da, ["t", "z", "y", "x"])
+        assert detect_object_type(da, resolved) == "tiled_array"
+
+
+# ===========================================================================
+# Lat/lon alias tiles (y → lat, x → lon)
+# ===========================================================================
+
+class TestLatLonAlias:
+    def test_single_tile_latlon_centroid(self):
+        da = make_single_tile_latlon(lat_coarse=51.0, lon_coarse=-1.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert "y" in result["centroid"]
+        assert "x" in result["centroid"]
+
+    def test_single_tile_latlon_bounds(self):
+        da = make_single_tile_latlon(lat_coarse=51.0, lon_coarse=-1.0, fine_steps=4)
+        result = get_bounds(da, expected="yx", by="tile")
+        assert "y" in result["bounds"]
+        assert "x" in result["bounds"]
+
+    def test_centroid_y_value_near_coarse(self):
+        # fine=[0,0.1,0.2,0.3]; coarse=51 → centroid ≈ 51.15
+        da = make_single_tile_latlon(lat_coarse=51.0, lon_coarse=0.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["centroid"]["y"] == pytest.approx(51.15, rel=0.01)
+
+
+# ===========================================================================
+# Negative coordinates
+# ===========================================================================
+
+class TestNegativeCoordinates:
+    def test_tile_centroid_negative(self):
+        da = make_single_tile_negative_coords()
+        result = get_centroids(da, expected="yx", by="tile")
+        # y_coarse=-40, fine=[0,1,2,3] → centroid_y = midpoint(-40.5, -36.5) = -38.5
+        assert result["centroid"]["y"] == pytest.approx(-38.5)
+        # x_coarse=-75, fine=[0,1,2,3] → centroid_x = midpoint(-75.5, -71.5) = -73.5
+        assert result["centroid"]["x"] == pytest.approx(-73.5)
+
+    def test_tile_bounds_negative(self):
+        da = make_single_tile_negative_coords()
+        result = get_bounds(da, expected="yx", by="tile")
+        y_min, y_max = result["bounds"]["y"]
+        assert y_min == pytest.approx(-40.5)
+        assert y_max == pytest.approx(-36.5)
+
+    def test_bounds_min_less_than_max_negative(self):
+        da = make_single_tile_negative_coords()
+        result = get_bounds(da, expected="yx", by="tile")
+        for letter, (mn, mx) in result["bounds"].items():
+            assert mn <= mx, f"bounds for {letter}: min={mn} > max={mx}"
+
+
+# ===========================================================================
+# ZYX and TZYX tiling
+# ===========================================================================
+
+class TestZYXTiling:
+    def test_zyx_centroid_has_z(self):
+        da = make_tiled_array_zyx(n_z=2, n_y=2, n_x=2)
+        result = get_centroids(da, expected="zyx", by="tile")
+        assert "centroid_z" in result
+        assert "centroid_y" in result
+        assert "centroid_x" in result
+
+    def test_zyx_chosen_yx_excludes_z(self):
+        da = make_tiled_array_zyx(n_z=2, n_y=2, n_x=2)
+        result = get_centroids(da, expected="zyx", chosen="yx", by="tile")
+        assert "centroid_z" not in result
+        assert "centroid_y" in result
+
+    def test_zyx_tile_count(self):
+        da = make_tiled_array_zyx(n_z=3, n_y=2, n_x=4)
+        result = get_centroids(da, expected="zyx", chosen="yx", by="tile")
+        assert result.sizes["tile"] == 24
+
+    def test_tzyx_full_centroid(self):
+        da = make_tiled_array_tzyx(n_t=2, n_z=2, n_y=2, n_x=2)
+        result = get_centroids(da, expected="tzyx", by="tile")
+        assert all(f"centroid_{l}" in result for l in ["t", "z", "y", "x"])
+
+    def test_tzyx_tile_count(self):
+        da = make_tiled_array_tzyx(n_t=2, n_z=3, n_y=2, n_x=2)
+        result = get_centroids(da, expected="tzyx", chosen="yx", by="tile")
+        assert result.sizes["tile"] == 24
+
+    def test_tzyx_chosen_single_dim(self):
+        da = make_tiled_array_tzyx(n_t=2, n_z=2, n_y=2, n_x=2)
+        result = get_centroids(da, expected="tzyx", chosen="t", by="tile")
+        assert "centroid_t" in result
+        assert "centroid_y" not in result
+        assert "centroid_x" not in result
+
+    def test_tzyx_bounds_chosen_yx(self):
+        da = make_tiled_array_tzyx(n_t=2, n_z=2, n_y=2, n_x=2)
+        result = get_bounds(da, expected="tzyx", chosen="yx", by="tile")
+        assert "bounds_y_min" in result
+        assert "bounds_x_min" in result
+        assert "bounds_t_min" not in result
+        assert "bounds_z_min" not in result
+
+
+# ===========================================================================
+# xr.Dataset input
+# ===========================================================================
+
+class TestDatasetInput:
+    def test_dataset_tile_centroid(self):
+        ds = make_dataset_single_tile()
+        result = get_centroids(ds, expected="yx", by="tile")
+        assert isinstance(result, dict)
+        assert "centroid" in result
+
+    def test_dataset_tile_bounds(self):
+        ds = make_dataset_single_tile()
+        result = get_bounds(ds, expected="yx", by="tile")
+        assert "bounds" in result
+        assert "y" in result["bounds"]
+
+
+# ===========================================================================
+# Non-MultiIndex tiled array (fallback path)
+# ===========================================================================
+
+class TestNonMultiIndexTiledArray:
+    def test_centroid_returns_dataset(self):
+        da = make_tiled_array_non_multiindex(n_y=2, n_x=3)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert isinstance(result, xr.Dataset)
+
+    def test_tile_count(self):
+        da = make_tiled_array_non_multiindex(n_y=2, n_x=3)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result.sizes["tile"] == 6
+
+    def test_bounds_min_less_than_max(self):
+        da = make_tiled_array_non_multiindex(n_y=2, n_x=2)
+        result = get_bounds(da, expected="yx", by="tile")
+        assert (result["bounds_y_min"].values <= result["bounds_y_max"].values).all()
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+class TestEdgeCases:
+    def test_1x1_tiled_array(self):
+        """A single-cell tiled array (1 tile) should still work."""
+        da = make_tiled_array(n_y=1, n_x=1)
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result.sizes["tile"] == 1
+
+    def test_large_step_size(self):
+        """Coarse steps of 100 000 (projected CRS units)."""
+        da = make_single_tile(y_coarse=500_000.0, x_coarse=300_000.0, fine_steps=10, crs="EPSG:27700")
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["centroid"]["y"] == pytest.approx(500_004.5)
+
+    def test_fine_steps_of_one(self):
+        """Tile with a single fine step — infer bounds as point geometry."""
+        fine_y = np.array([0.0])
+        fine_x = np.array([0.0])
+        da = xr.DataArray(
+            np.ones((1, 1)),
+            dims=["y_fine", "x_fine"],
+            coords={"y_fine": fine_y, "x_fine": fine_x, "y_coarse": 10.0, "x_coarse": 20.0},
+        )
+        da.attrs["crs"] = "EPSG:4326"
+        result = get_centroids(da, expected="yx", by="tile")
+        assert result["centroid"]["y"] == pytest.approx(10.0)
+        assert result["centroid"]["x"] == pytest.approx(20.0)
+
+    def test_chosen_equals_expected(self):
+        """When chosen == expected, all dims are returned."""
+        da = make_single_tile()
+        result = get_centroids(da, expected="yx", chosen="yx", by="tile")
+        assert "y" in result["centroid"]
+        assert "x" in result["centroid"]
+
+    def test_tiled_array_centroid_values_correct(self):
+        """
+        For a 2-tile grid (n_y=2) with step_size=10 and fine_steps=4:
+          step per pixel = 10/4 = 2.5
+          offsets = [0, 2.5, 5, 7.5] -> fine_min=-1.25, fine_max=8.75
+
+          tile 0: coarse_y=0,  centroid_y = midpoint(-1.25, 8.75) = 3.75
+          tile 1: coarse_y=10, centroid_y = midpoint(8.75, 18.75) = 13.75
+        """
+        da = make_tiled_array(n_y=2, n_x=1, fine_steps=4, step_size=10.0)
+        result = get_centroids(da, expected="yx", chosen="y", by="tile")
+        centroids = sorted(result["centroid_y"].values.tolist())
+        assert centroids[0] == pytest.approx(3.75)
+        assert centroids[1] == pytest.approx(13.75)
+
+    def test_bounds_width_consistent_across_tiles(self):
+        """All tiles in a uniform grid should have the same width."""
+        da = make_tiled_array(n_y=3, n_x=3, fine_steps=4, step_size=10.0)
+        result = get_bounds(da, expected="yx", by="tile")
+        widths = result["bounds_y_max"].values - result["bounds_y_min"].values
+        assert np.allclose(widths, widths[0]), "All tiles should have equal height"
+
+    def test_centroid_is_midpoint_of_bounds(self):
+        """Centroid must always equal midpoint(bounds_min, bounds_max)."""
+        da = make_tiled_array(n_y=3, n_x=3, fine_steps=5, step_size=8.0)
+        centroids = get_centroids(da, expected="yx", by="tile")
+        bounds = get_bounds(da, expected="yx", by="tile")
+        for letter in ["y", "x"]:
+            c = centroids[f"centroid_{letter}"].values
+            mn = bounds[f"bounds_{letter}_min"].values
+            mx = bounds[f"bounds_{letter}_max"].values
+            expected_c = (mn + mx) / 2.0
+            np.testing.assert_allclose(c, expected_c, rtol=1e-10,
+                err_msg=f"centroid_{letter} != midpoint of bounds")
+
+
+# ===========================================================================
+# Datetime coordinate handling (bug fix: t should return datetime64, not int)
+# ===========================================================================
+
+def make_tiled_array_with_datetime_t(
+    n_t: int = 3,
+    n_y: int = 2,
+    n_x: int = 2,
+    fine_steps: int = 4,
+    crs: str = "EPSG:4326",
+) -> xr.DataArray:
+    """
+    Tiled array where t_coarse and t_fine are numpy.datetime64 values,
+    as would be produced from real ERA5 data.
+    """
+    base = np.datetime64("2020-01-01", "ns")
+    day = np.timedelta64(1, "D").astype("timedelta64[ns]")
+
+    coarse_t = np.array([base + i * day * fine_steps for i in range(n_t)])
+    fine_t   = np.array([base + i * day for i in range(fine_steps)])
+
+    coarse_y = np.arange(n_y, dtype=float) * 10.0
+    coarse_x = np.arange(n_x, dtype=float) * 10.0
+    fine_y   = np.arange(fine_steps, dtype=float)
+    fine_x   = np.arange(fine_steps, dtype=float)
+
+    n_tiles = n_t * n_y * n_x
+    data = np.random.rand(n_tiles, fine_steps, fine_steps, fine_steps)
+
+    tile_index = pd.MultiIndex.from_product(
+        [coarse_t, coarse_y, coarse_x],
+        names=["time_coarse", "y_coarse", "x_coarse"],
+    )
+    tile_coord = xr.Coordinates.from_pandas_multiindex(tile_index, "tile")
+
+    da = xr.DataArray(
+        data,
+        dims=["tile", "time_fine", "y_fine", "x_fine"],
+        coords={
+            **tile_coord,
+            "time_fine": fine_t,
+            "y_fine": fine_y,
+            "x_fine": fine_x,
+        },
+    )
+    da.attrs["crs"] = crs
+    return da
+
+
+class TestDatetimeCoords:
+    def test_tile_centroid_t_default_is_float(self):
+        """t centroid defaults to float ns — for model consumption."""
+        da = make_tiled_array_with_datetime_t(n_t=1, n_y=1, n_x=1, fine_steps=4)
+        single = da.isel(tile=0)
+        single = single.assign_coords(
+            time_coarse=da.coords["time_coarse"].values[0],
+            y_coarse=da.coords["y_coarse"].values[0],
+            x_coarse=da.coords["x_coarse"].values[0],
+        )
+        result = get_centroids(single, expected="tyx", by="tile")
+        t_val = result["centroid"]["t"]
+        assert isinstance(t_val, float), f"Expected float, got {type(t_val)}"
+
+    def test_tile_centroid_t_is_datetime_with_flag(self):
+        """t centroid with time_as_datetime=True should be datetime64."""
+        da = make_tiled_array_with_datetime_t(n_t=1, n_y=1, n_x=1, fine_steps=4)
+        single = da.isel(tile=0)
+        single = single.assign_coords(
+            time_coarse=da.coords["time_coarse"].values[0],
+            y_coarse=da.coords["y_coarse"].values[0],
+            x_coarse=da.coords["x_coarse"].values[0],
+        )
+        result = get_centroids(single, expected="tyx", time_as_datetime=True, by="tile")
+        t_val = result["centroid"]["t"]
+        assert np.issubdtype(np.asarray(t_val).dtype, np.datetime64), (
+            f"Expected datetime64, got {type(t_val)} / {np.asarray(t_val).dtype}"
+        )
+
+    def test_tiled_array_centroid_t_default_is_float(self):
+        """t centroid in a Dataset defaults to float64."""
+        da = make_tiled_array_with_datetime_t(n_t=3, n_y=2, n_x=2, fine_steps=4)
+        result = get_centroids(da, expected="tyx", chosen="t", by="tile")
+        assert "centroid_t" in result
+        assert np.issubdtype(result["centroid_t"].values.dtype, np.floating), (
+            f"Expected float dtype, got {result['centroid_t'].values.dtype}"
+        )
+
+    def test_tiled_array_centroid_t_is_datetime_with_flag(self):
+        """t centroid in a Dataset with time_as_datetime=True → datetime64."""
+        da = make_tiled_array_with_datetime_t(n_t=3, n_y=2, n_x=2, fine_steps=4)
+        result = get_centroids(da, expected="tyx", chosen="t", time_as_datetime=True, by="tile")
+        assert "centroid_t" in result
+        assert np.issubdtype(result["centroid_t"].values.dtype, np.datetime64), (
+            f"Expected datetime64 dtype, got {result['centroid_t'].values.dtype}"
+        )
+
+    def test_tiled_array_bounds_t_is_datetime_with_flag(self):
+        """t bounds with time_as_datetime=True → datetime64 min/max."""
+        da = make_tiled_array_with_datetime_t(n_t=3, n_y=2, n_x=2, fine_steps=4)
+        result = get_bounds(da, expected="tyx", chosen="t", time_as_datetime=True, by="tile")
+        assert "bounds_t_min" in result
+        assert "bounds_t_max" in result
+        assert np.issubdtype(result["bounds_t_min"].values.dtype, np.datetime64)
+        assert np.issubdtype(result["bounds_t_max"].values.dtype, np.datetime64)
+
+    def test_tiled_array_t_bounds_ordered(self):
+        """t bounds min should always be <= max (works in float mode)."""
+        da = make_tiled_array_with_datetime_t(n_t=3, n_y=2, n_x=2, fine_steps=4)
+        result = get_bounds(da, expected="tyx", chosen="t", by="tile")
+        assert (result["bounds_t_min"].values <= result["bounds_t_max"].values).all()
+
+    def test_tiled_array_t_centroids_monotonic(self):
+        """t centroids should increase as the t_coarse index increases."""
+        da = make_tiled_array_with_datetime_t(n_t=4, n_y=1, n_x=1, fine_steps=4)
+        result = get_centroids(da, expected="tyx", chosen="t", by="tile")
+        vals = result["centroid_t"].values
+        assert np.all(np.diff(vals) > 0), "t centroids should be strictly increasing"
+
+    def test_spatial_coords_still_float_when_t_present(self):
+        """y/x centroids remain float regardless of time_as_datetime."""
+        da = make_tiled_array_with_datetime_t(n_t=2, n_y=2, n_x=2, fine_steps=4)
+        result = get_centroids(da, expected="tyx", time_as_datetime=True, by="tile")
+        assert np.issubdtype(result["centroid_y"].values.dtype, np.floating)
+        assert np.issubdtype(result["centroid_x"].values.dtype, np.floating)
+
+
+# ===========================================================================
+# expected= raises on untiled / mismatched objects (bug fix)
+# ===========================================================================
+
+class TestExpectedStrictEnforcement:
+    def test_tiled_object_missing_expected_dim_raises(self):
+        """Tiled DataArray passed with expected= for a dim it lacks should raise."""
+        da = make_tiled_array(n_y=2, n_x=2)  # has y_coarse/x_coarse, no t or z
+        with pytest.raises(ExpectedDimsMismatchError):
+            get_centroids(da, expected="tyx", by="tile")  # t not present → raise
+
+    def test_tyx_object_with_tzyx_expected_raises(self):
+        """tyx tiled array passed with expected='tzyx' should raise for missing z."""
+        da = make_tiled_array(n_y=2, n_x=2)  # only y_coarse/x_coarse, no t or z
+        with pytest.raises(ExpectedDimsMismatchError):
+            get_centroids(da, expected="tzyx", by="tile")
+
+    def test_yx_object_with_tyx_expected_raises(self):
+        """yx tiled array passed with expected='tyx' should raise for missing t."""
+        da = make_tiled_array(n_y=2, n_x=2)
+        with pytest.raises(ExpectedDimsMismatchError):
+            get_centroids(da, expected="tyx", by="tile")
+
+    def test_tyx_object_with_tyx_expected_passes(self):
+        """tyx tiled array with expected='tyx' should not raise."""
+        da = make_tiled_array_tzyx(n_t=2, n_z=1, n_y=2, n_x=2)
+        result = get_centroids(da, expected="tzyx", chosen="yx", by="tile")
+        assert isinstance(result, xr.Dataset)
+
+    def test_expected_none_on_untiled_object_does_not_raise(self):
+        """No expected= on a pixel object should succeed (auto-discovery)."""
+        da = make_pixel()
+        del da.attrs["crs"]  # rely on lat/lon heuristic
+        result = get_centroids(da, by="tile")
+        assert isinstance(result, dict)
+
+    def test_expected_partial_match_raises(self):
+        """Object with y/x tiling but expected='zyx' should raise for missing z."""
+        da = make_tiled_array(n_y=2, n_x=2)
+        with pytest.raises(ExpectedDimsMismatchError):
+            get_centroids(da, expected="zyx", by="tile")
+
+# ===========================================================================
+# by="pixel" — per-pixel output
+# ===========================================================================
+
+class TestByPixel:
+    def test_tile_pixel_centroid_returns_dataset(self):
+        """by='pixel' on a single tile returns an xr.Dataset."""
+        da = make_single_tile(y_coarse=0.0, x_coarse=0.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="pixel")
+        assert isinstance(result, xr.Dataset)
+
+    def test_tile_pixel_centroid_has_fine_dim(self):
+        """Per-pixel centroid Dataset is indexed by the fine dimension."""
+        da = make_single_tile(y_coarse=0.0, x_coarse=0.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="pixel")
+        assert "centroid_y" in result
+        assert "centroid_x" in result
+        # Indexed by y_fine / x_fine, not a 'tile' dim
+        assert "y_fine" in result.dims or "x_fine" in result.dims
+
+    def test_tile_pixel_centroid_length(self):
+        """Per-pixel centroid has one entry per fine step."""
+        fine_steps = 6
+        da = make_single_tile(fine_steps=fine_steps)
+        result = get_centroids(da, expected="yx", by="pixel")
+        assert result["centroid_y"].size == fine_steps
+        assert result["centroid_x"].size == fine_steps
+
+    def test_tile_pixel_centroid_values_absolute(self):
+        """
+        Per-pixel centroids should be absolute coords, not indices.
+        With y_coarse=10, fine=[0,1,2,3] -> pixel centroids = [10, 11, 12, 13]
+        (fine indices treated as unit offsets from coarse origin).
+        """
+        da = make_single_tile(y_coarse=10.0, x_coarse=20.0, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="pixel")
+        y_centroids = result["centroid_y"].values
+        assert y_centroids[0] == pytest.approx(10.0)
+        assert y_centroids[-1] == pytest.approx(13.0)
+
+    def test_tile_pixel_bounds_returns_dataset(self):
+        """by='pixel' bounds on a tile returns an xr.Dataset."""
+        da = make_single_tile(fine_steps=4)
+        result = get_bounds(da, expected="yx", by="pixel")
+        assert isinstance(result, xr.Dataset)
+        assert "bounds_y_min" in result
+        assert "bounds_y_max" in result
+
+    def test_tile_pixel_bounds_min_less_than_max(self):
+        """Per-pixel bounds min should always be <= max."""
+        da = make_single_tile(y_coarse=0.0, x_coarse=0.0, fine_steps=5)
+        result = get_bounds(da, expected="yx", by="pixel")
+        assert (result["bounds_y_min"].values <= result["bounds_y_max"].values).all()
+        assert (result["bounds_x_min"].values <= result["bounds_x_max"].values).all()
+
+    def test_tile_pixel_centroid_equals_midpoint_of_bounds(self):
+        """Per-pixel centroid should equal midpoint of per-pixel bounds."""
+        da = make_single_tile(y_coarse=5.0, x_coarse=3.0, fine_steps=6)
+        centroids = get_centroids(da, expected="yx", by="pixel")
+        bounds = get_bounds(da, expected="yx", by="pixel")
+        for letter in ["y", "x"]:
+            c = centroids[f"centroid_{letter}"].values
+            mn = bounds[f"bounds_{letter}_min"].values
+            mx = bounds[f"bounds_{letter}_max"].values
+            np.testing.assert_allclose(c, (mn + mx) / 2.0, rtol=1e-10)
+
+    def test_tiled_array_pixel_centroid_returns_dataset(self):
+        """by='pixel' on a tiled array returns xr.Dataset."""
+        da = make_tiled_array(n_y=2, n_x=2, fine_steps=4)
+        result = get_centroids(da, expected="yx", by="pixel")
+        assert isinstance(result, xr.Dataset)
+
+    def test_tiled_array_pixel_centroid_dims(self):
+        """Tiled array per-pixel centroid has (tile, fine_dim) shape."""
+        n_y, n_x, fine_steps = 2, 3, 4
+        da = make_tiled_array(n_y=n_y, n_x=n_x, fine_steps=fine_steps)
+        result = get_centroids(da, expected="yx", by="pixel")
+        assert result["centroid_y"].shape == (n_y * n_x, fine_steps)
+        assert result["centroid_x"].shape == (n_y * n_x, fine_steps)
+
+    def test_tiled_array_pixel_bounds_dims(self):
+        """Tiled array per-pixel bounds have (tile, fine_dim) shape."""
+        n_y, n_x, fine_steps = 2, 2, 5
+        da = make_tiled_array(n_y=n_y, n_x=n_x, fine_steps=fine_steps)
+        result = get_bounds(da, expected="yx", by="pixel")
+        assert result["bounds_y_min"].shape == (n_y * n_x, fine_steps)
+        assert result["bounds_x_max"].shape == (n_y * n_x, fine_steps)
+
+    def test_tiled_array_pixel_centroids_monotonic_across_tiles(self):
+        """Pixel centroids should increase across tiles as coarse index increases."""
+        da = make_tiled_array(n_y=3, n_x=1, fine_steps=4, step_size=10.0)
+        result = get_centroids(da, expected="yx", chosen="y", by="pixel")
+        # First pixel of each successive tile should be larger than last of previous
+        tile_first = result["centroid_y"].values[:, 0]
+        assert np.all(np.diff(tile_first) > 0)
+
+    def test_by_invalid_raises(self):
+        """Invalid by= value should raise ValueError."""
+        da = make_single_tile()
+        with pytest.raises(ValueError, match="`by`"):
+            get_centroids(da, expected="yx", by="banana")
+
+    def test_pixel_object_by_pixel_same_as_by_tile(self):
+        """For a plain pixel object, by='pixel' and by='tile' return the same thing."""
+        da = make_pixel()
+        del da.attrs["crs"]
+        r_tile = get_centroids(da, by="tile")
+        r_pixel = get_centroids(da, by="pixel")
+        assert r_tile["centroid"] == r_pixel["centroid"]
+
+    def test_chosen_respected_in_pixel_mode(self):
+        """chosen= should still filter dims in by='pixel' mode."""
+        da = make_single_tile(fine_steps=4)
+        result = get_centroids(da, expected="yx", chosen="y", by="pixel")
+        assert "centroid_y" in result
+        assert "centroid_x" not in result

--- a/tests/geometry/test_geometry_utils_datasets.py
+++ b/tests/geometry/test_geometry_utils_datasets.py
@@ -1,0 +1,258 @@
+from pathlib import Path
+
+import pytest
+import pandas as pd
+import numpy as np
+import pyproj
+
+from FRAME_FM.transforms import *
+from FRAME_FM.transforms.transforms import transform_mapping
+from FRAME_FM.utils.data_utils import load_data_from_uri
+
+#from tests.datasets.common import CHESS_URI, ERA5_URI
+
+from FRAME_FM.utils.geometry_utils import get_centroids, get_bounds
+import FRAME_FM.utils.geometry_utils.exceptions as geo_exceptions
+
+CHESS_URI = "/gws/ssde/j25b/eds_ai/frame-fm/data/inputs/chess-met/aggregations/chess-met_precip_gb_1km_daily_19610101-20191231.nca" # 12M
+ERA5_URI = "tests/transforms/fixtures/ecmwf-era5X_oper_an_sfc_2000_2020_2d_repack.kr1.0.json.zip" # 1.3M
+
+pdt = pd.to_datetime
+
+dsets = {
+    "era5": {
+        "uri": ERA5_URI,
+        "main_var": "d2m",
+        "ds": None,
+    },
+    "chessmet": {
+        "uri": CHESS_URI,
+        "main_var": "precip",
+        "ds": None,
+    },
+}
+
+
+def _convert_point(point: tuple[float, float], from_crs: str = "EPSG:4326", to_crs: str = "EPSG:4326") -> tuple[float, float]:
+    transformer = pyproj.Transformer.from_crs(from_crs, to_crs, always_xy=True)
+    x, y = transformer.transform(point[0], point[1])
+    return x, y
+
+
+def _load_data(source: str = "era5", response_type: str = "Dataset") -> xr.Dataset | xr.DataArray:
+    global dsets
+    if dsets[source]["ds"] is None:
+        dsets[source]["ds"] = load_data_from_uri(dsets[source]["uri"], chunks="auto")   # type: ignore
+
+    var_id = dsets[source]["main_var"]
+    if response_type == "DataArray":
+        resp = dsets[source]["ds"][var_id].isel(time=slice(0, 3))
+    else:
+        resp = dsets[source]["ds"]
+
+    return resp, var_id
+
+
+def _load_era5_data(response_type: str = "Dataset") -> xr.Dataset | xr.DataArray:
+    da, var_id = _load_data(source="era5", response_type="DataArray")
+
+    # Reduce the size of the array to 300 x 300 lat and lons and then tile it to 9 x 9 tiles of 100 x 100 lat and lons
+    da = da.isel(latitude=slice(0, 300), longitude=slice(0, 300))
+    return da
+
+
+def _load_chessmet_data(response_type: str = "Dataset") -> xr.Dataset | xr.DataArray:
+    da, var_id = _load_data(source="chessmet", response_type="DataArray")
+
+    # Reduce the size of the array to 300 x 300 y and x and then tile it to 9 x 9 tiles of 100 x 100 y and x
+    da = da.isel(x=slice(0, 300), y=slice(0, 300))
+    return da
+
+
+def test_get_centroids_era5_tile_by_tile():
+    da = _load_era5_data(response_type="DataArray")
+    tiled = TilerTransform(time=2, latitude=100, longitude=100, boundary="pad")(da)
+
+    tile = tiled.isel(batch_dim=0)
+    with pytest.raises(geo_exceptions.ExpectedDimsMismatchError, match="Object does not match `expected` dims 'tzyx'.*"):
+        get_centroids(tile, expected="tzyx", chosen="yx", by="tile")
+
+    result = get_centroids(tile, expected="tyx", chosen="yx", by="tile")
+    assert result == {'centroid': {'y': 77.625, 'x': 12.375}, 'crs': 'EPSG:4326'}, f"Centroid calculation for tiled ERA5 lat/lon failed, response was: {result}."
+    # Get only the y (latitude) centroid
+    result_y = get_centroids(tile, expected="tyx", chosen="y", by="tile")
+    assert result_y == {'centroid': {'y': 77.625}, 'crs': 'EPSG:4326'}, f"Centroid calculation for tiled ERA5 latitude failed, response was: {result_y}."
+
+    # Get back time only, as a datetime object
+    result_t = get_centroids(tile, expected="tyx", chosen="t", time_as_datetime=True, by="tile")
+    assert result_t == {'centroid': {'t': np.datetime64('2000-01-01T00:30:00.000000000')}, 'crs': 'EPSG:4326'}, f"Centroid calculation for tiled ERA5 time failed, response was: {result_t}."
+
+
+def test_get_centroids_era5_tile_by_pixel():
+    da = _load_era5_data(response_type="DataArray")
+    tiled = TilerTransform(time=2, latitude=5, longitude=5, boundary="pad")(da)
+
+    tile = tiled.isel(batch_dim=0)
+    with pytest.raises(geo_exceptions.ExpectedDimsMismatchError, match="Object does not match `expected` dims 'tzyx'.*"):
+        get_centroids(tile, expected="tzyx", chosen="yx", by="pixel")
+
+    result = get_centroids(tile, expected="tyx", chosen="yx", by="pixel")
+    # Check y and x centroids are the same in both results, and that the CRS is correct
+    assert np.array_equal(result["centroid_y"], tile["latitude"].values), f"Centroid calculation for tiled ERA5 latitude by pixel failed, response was: {result}."
+    assert np.array_equal(result["centroid_x"], tile["longitude"].values), f"Centroid calculation for tiled ERA5 longitude by pixel failed, response was: {result}."
+
+    # Get only the y (latitude) centroid
+    result_y = get_centroids(tile, expected="tyx", chosen="y", by="pixel")
+    # Check y centroids are the same in both results, and that the CRS is correct
+    assert np.array_equal(result_y["centroid_y"], tile["latitude"].values), f"Centroid calculation for tiled ERA5 latitude by pixel failed, response was: {result_y}."
+
+    # Get back time only, as a datetime object
+    result_t = get_centroids(tile, expected="tyx", chosen="t", time_as_datetime=True, by="tile")
+    # Check time centroid is the same in both results, and that the CRS is correct
+    assert np.array_equal(result_t["centroid"]["t"], np.datetime64('2000-01-01T00:30:00.000000000')), f"Centroid calculation for tiled ERA5 time failed, response was: {result_t}."
+
+
+def test_get_bounds_era5_tile_by_pixel():
+    da = _load_era5_data(response_type="DataArray")
+    tiled = TilerTransform(time=2, latitude=5, longitude=5, boundary="pad")(da)
+
+    tile = tiled.isel(batch_dim=0)
+    with pytest.raises(geo_exceptions.ExpectedDimsMismatchError, match="Object does not match `expected` dims 'tzyx'.*"):
+        get_bounds(tile, expected="tzyx", chosen="yx", by="pixel")
+
+    result = get_bounds(tile, expected="tyx", chosen="yx", by="pixel")
+
+    # Calculate the bounds for latitude and longitude by pixel, which should be the same
+    bounds_y = []
+    tile_lats = tile["latitude"].values
+    y_interval = (tile_lats[1] - tile_lats[0]) / 2
+    for i in range(len(tile["latitude"].values)):
+        v = tile_lats[i]
+        bounds_y.append((v - y_interval, v + y_interval))
+
+    bounds_x = []
+    tile_lons = tile["longitude"].values    
+    x_interval = (tile_lons[1] - tile_lons[0]) / 2
+    for i in range(len(tile["longitude"].values)):
+        v = tile_lons[i]
+        bounds_x.append((v - x_interval, v + x_interval))
+
+    bounds_y_min = np.array(bounds_y)[:, 0]
+    bounds_y_max = np.array(bounds_y)[:, 1]
+    bounds_x_min = np.array(bounds_x)[:, 0]
+    bounds_x_max = np.array(bounds_x)[:, 1]
+
+    assert np.array_equal(result["bounds_y_min"], bounds_y_min), f"Bounds y min does not match expected values for tiled ERA5 latitude by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_y_max"], bounds_y_max), f"Bounds y max does not match expected values for tiled ERA5 latitude by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_x_min"], bounds_x_min), f"Bounds x min does not match expected values for tiled ERA5 longitude by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_x_max"], bounds_x_max), f"Bounds x max does not match expected values for tiled ERA5 longitude by pixel, response was: {result}."
+
+    # Get only the y (latitude) bounds
+    result_y = get_bounds(tile, expected="tyx", chosen="y", by="pixel")
+    # Check y bounds are the same in both results, and that the CRS is correct
+    assert np.array_equal(result["bounds_y_min"], bounds_y_min), f"Bounds y min does not match expected values for tiled ERA5 latitude by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_y_max"], bounds_y_max), f"Bounds y max does not match expected values for tiled ERA5 latitude by pixel, response was: {result}."
+
+    # Get back time only, as a datetime object
+    result_t = get_bounds(tile, expected="tyx", chosen="t", time_as_datetime=True, by="tile")
+    # Check time bounds is the same in both results, and that the CRS is correct
+    assert np.array_equal(result_t["bounds"]["t"], np.array(
+        (np.datetime64('1999-12-31T23:30:00.000000000'), np.datetime64('2000-01-01T01:30:00.000000000')),
+        )), f"Bounds calculation for tiled ERA5 time failed, response was: {result_t}."
+
+
+def test_get_centroids_chessmet_tile_by_pixel():
+    da = _load_chessmet_data(response_type="DataArray")
+    tiled = TilerTransform(time=2, y=5, x=5, boundary="pad")(da)
+
+    tile = tiled.isel(batch_dim=0)
+    with pytest.raises(geo_exceptions.ExpectedDimsMismatchError, match="Object does not match `expected` dims 'tzyx'.*"):
+        get_centroids(tile, expected="tzyx", chosen="yx", by="pixel")
+
+    result = get_centroids(tile, expected="tyx", chosen="yx", by="pixel")
+    # Check y and x centroids are the same in both results, and that the CRS is correct
+    assert np.array_equal(result["centroid_y"], tile["y"].values), f"Centroid calculation for tiled CHESSMet y by pixel failed, response was: {result}."
+    assert np.array_equal(result["centroid_x"], tile["x"].values), f"Centroid calculation for tiled CHESSMet x by pixel failed, response was: {result}."
+
+    # Get only the y (latitude) centroid
+    result_y = get_centroids(tile, expected="tyx", chosen="y", by="pixel")
+    # Check y centroids are the same in both results, and that the CRS is correct
+    assert np.array_equal(result_y["centroid_y"], tile["y"].values), f"Centroid calculation for tiled CHESSMet y by pixel failed, response was: {result_y}."
+
+    # Get back time only, as a datetime object
+    result_t = get_centroids(tile, expected="tyx", chosen="t", time_as_datetime=True, by="tile")
+    # Check time centroid is the same in both results, and that the CRS is correct
+    assert np.array_equal(result_t["centroid"]["t"], np.datetime64('1961-01-01T12:00:00.000000000')), f"Centroid calculation for tiled CHESSMet time failed, response was: {result_t}."
+
+
+def test_get_bounds_chessmet_tile_by_pixel():
+    da = _load_chessmet_data(response_type="DataArray")
+    tiled = TilerTransform(time=2, y=5, x=5, boundary="pad")(da)
+
+    tile = tiled.isel(batch_dim=0)
+    with pytest.raises(geo_exceptions.ExpectedDimsMismatchError, match="Object does not match `expected` dims 'tzyx'.*"):
+        get_bounds(tile, expected="tzyx", chosen="yx", by="pixel")
+
+    result = get_bounds(tile, expected="tyx", chosen="yx", by="pixel")
+
+    # Calculate the bounds for latitude and longitude by pixel, which should be the same
+    bounds_y = []
+    tile_lats = tile["y"].values
+    y_interval = (tile_lats[1] - tile_lats[0]) / 2
+    for i in range(len(tile["y"].values)):
+        v = tile_lats[i]
+        bounds_y.append((v - y_interval, v + y_interval))
+
+    bounds_x = []
+    tile_lons = tile["x"].values
+    x_interval = (tile_lons[1] - tile_lons[0]) / 2
+    for i in range(len(tile["x"].values)):
+        v = tile_lons[i]
+        bounds_x.append((v - x_interval, v + x_interval))
+
+    bounds_y_min = np.array(bounds_y)[:, 0]
+    bounds_y_max = np.array(bounds_y)[:, 1]
+    bounds_x_min = np.array(bounds_x)[:, 0]
+    bounds_x_max = np.array(bounds_x)[:, 1]
+
+    assert np.array_equal(result["bounds_y_min"], bounds_y_min), f"Bounds y min does not match expected values for tiled CHESSMet y by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_y_max"], bounds_y_max), f"Bounds y max does not match expected values for tiled CHESSMet y by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_x_min"], bounds_x_min), f"Bounds x min does not match expected values for tiled CHESSMet x by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_x_max"], bounds_x_max), f"Bounds x max does not match expected values for tiled CHESSMet x by pixel, response was: {result}."
+
+    # Check CRS is correct
+    assert result.crs == "crsOSGB", f"CRS does not match expected value for tiled CHESSMet by pixel, response was: {result}."
+
+    # Get only the y (latitude) bounds
+    result_y = get_bounds(tile, expected="tyx", chosen="y", by="pixel")
+    # Check y bounds are the same in both results, and that the CRS is correct
+    assert np.array_equal(result["bounds_y_min"], bounds_y_min), f"Bounds y min does not match expected values for tiled CHESSMet y by pixel, response was: {result}."
+    assert np.array_equal(result["bounds_y_max"], bounds_y_max), f"Bounds y max does not match expected values for tiled CHESSMet y by pixel, response was: {result}."
+
+    # Get back time only, as a datetime object
+    result_t = get_bounds(tile, expected="tyx", chosen="t", time_as_datetime=True, by="tile")
+    # Check time bounds is the same in both results, and that the CRS is correct
+    assert np.array_equal(result_t["bounds"]["t"], np.array(
+        (np.datetime64('1960-12-31T12:00:00.000000000'), np.datetime64('1961-01-02T12:00:00.000000000')),
+        )), f"Bounds calculation for tiled CHESSMet time failed, response was: {result_t}."
+
+
+def test_get_centroids_chessmet_tile_by_pixel_as_epsg_4326():
+    da = _load_chessmet_data(response_type="DataArray")
+    tiled = TilerTransform(time=2, y=5, x=5, boundary="pad")(da)
+    tile = tiled.isel(batch_dim=0)
+
+    result_lat_lon = get_centroids(tile, expected="tyx", chosen="yx", by="pixel", crs="EPSG:27700", target_crs="EPSG:4326")
+    result = get_centroids(tile, expected="tyx", chosen="yx", by="pixel")
+
+    # First centroid should be the same as the original, but transformed to EPSG:4326
+    expected_first_centroid = _convert_point((result["centroid_x"][0], result["centroid_y"][0]), from_crs="EPSG:27700", to_crs="EPSG:4326")
+    assert np.allclose(result_lat_lon["centroid_x"][0], expected_first_centroid[0]), f"Centroid x coordinate does not match expected value for tiled CHESSMet x by pixel with CRS transformation, response was: {result_lat_lon}."
+    assert np.allclose(result_lat_lon["centroid_y"][0], expected_first_centroid[1]), f"Centroid y coordinate does not match expected value for tiled CHESSMet y by pixel with CRS transformation, response was: {result_lat_lon}."
+
+    # Final centroid should be the same as the original, but transformed to EPSG:4326
+    expected_final_centroid = _convert_point((result["centroid_x"][-1], result["centroid_y"][-1]), from_crs="EPSG:27700", to_crs="EPSG:4326")
+    assert np.allclose(result_lat_lon["centroid_x"][-1], expected_final_centroid[0]), f"Centroid x coordinate does not match expected value for tiled CHESSMet x by pixel with CRS transformation, response was: {result_lat_lon}."
+    assert np.allclose(result_lat_lon["centroid_y"][-1], expected_final_centroid[1]), f"Centroid y coordinate does not match expected value for tiled CHESSMet y by pixel with CRS transformation, response was: {result_lat_lon}."
+
+    


### PR DESCRIPTION
Added a sub-package: `src/FRAME_FM/utils/geometry_utils` to support reverse lookups of centroids and bounds on pixel / tile / tile-array objects. 

# geometry_utils

Centroid and bounds extraction for tiled Xarray objects.

Designed for ML data pipelines that produce tiled datasets via the
`coarsen() → construct() → stack() → transpose()` pattern, using
`<coord>_coarse` / `<coord>_fine` coordinate naming.

---

## Features

- **Auto-detects object type** — single pixel, single tile, or a DataArray of many tiles
- **Works with any tiling combination** — T, Z, Y, X or any subset
- **Coordinate alias resolution** — `y` resolves to `lat`, `latitude`, or `y`; likewise for `x`, `t`, `z`
- **Always infers bounds** — no need for explicit bounds coordinates; inferred from coordinate spacing
- **Optional CRS reprojection** — reproject results to any target CRS via pyproj
- **`expected` / `chosen` API** — validate the object's tiling structure and select which dims to return
- **Get back datetimes or floats for time** - useful for different use cases
- **Get response by pixel or tile/array** - using the `by` parameter

---

## Quick start

```python
from geometry_utils import get_centroids, get_bounds
```

### Single tile

```python
result = get_centroids(tile_da, expected="yx", crs="EPSG:4326")
# {'centroid': {'y': 51.5, 'x': -0.1}, 'crs': 'EPSG:4326'}

result = get_bounds(tile_da, expected="yx")
# {'bounds': {'y': (51.0, 52.0), 'x': (-0.5, 0.3)}, 'crs': 'EPSG:4326'}
```